### PR TITLE
feat: coder ppcommit --base

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,24 @@ You can also run from anywhere and point at a workspace:
 coder --workspace /path/to/workspace
 ```
 
-If the repo’s test command can’t be auto-detected, pass one explicitly:
+If the repo's test command can't be auto-detected, pass one explicitly:
 
 ```bash
 coder --test-cmd "pnpm test"
+```
+
+### `coder ppcommit`
+
+Run ppcommit checks on all files in the repository:
+
+```bash
+coder ppcommit
+```
+
+To check only files changed since a specific branch (PR-scope review):
+
+```bash
+coder ppcommit --base main
 ```
 
 By default, `coder` will:

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -48,6 +48,7 @@ import {
   sanitizeIssueMarkdown,
   buildPrBodyFromIssue,
   DEFAULT_PASS_ENV,
+  detectDefaultBranch,
 } from "./helpers.js";
 
 const GEMINI_LIST_MODEL = "gemini-2.5-flash";
@@ -1484,22 +1485,7 @@ Hard constraints:
     if (repoPath) {
       const repoRoot = path.resolve(this.workspaceDir, repoPath);
       if (existsSync(repoRoot)) {
-        // Determine default branch
-        let defaultBranch = "main";
-        const originHead = spawnSync("git", ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], {
-          cwd: repoRoot, encoding: "utf8",
-        });
-        if (originHead.status === 0) {
-          const raw = (originHead.stdout || "").trim();
-          if (raw.startsWith("origin/") && raw.length > "origin/".length) {
-            defaultBranch = raw.slice("origin/".length);
-          }
-        } else {
-          const mainCheck = spawnSync("git", ["rev-parse", "--verify", "main"], {
-            cwd: repoRoot, encoding: "utf8",
-          });
-          defaultBranch = mainCheck.status === 0 ? "main" : "master";
-        }
+        const defaultBranch = detectDefaultBranch(repoRoot);
 
         const checkout = spawnSync("git", ["checkout", defaultBranch], { cwd: repoRoot, encoding: "utf8" });
         if (checkout.status !== 0) {


### PR DESCRIPTION
Adds a 'coder ppcommit' CLI subcommand (all files or --base PR-scope).\n\nFixes an edge case where an invalid/missing --base ref could silently report 'no changes' and skip checks; now hard-fails with a clear error.\n\nIncludes regression test.