### PR TITLE
chore: update default models to gemini-3.1-pro-preview and claude-sonnet-4-6

### DIFF
--- a/coder.example.json
+++ b/coder.example.json
@@ -1,7 +1,7 @@
 {
   "models": {
     "gemini": {
-      "model": "gemini-3-flash-preview",
+      "model": "gemini-3.1-pro-preview",
       "apiEndpoint": "https://generativelanguage.googleapis.com/v1beta",
       "apiKeyEnv": "GEMINI_API_KEY"
     },

--- a/src/agents/api-agent.js
+++ b/src/agents/api-agent.js
@@ -99,7 +99,7 @@ export class ApiAgent extends AgentAdapter {
   }
 
   async _callAnthropic(prompt) {
-    const model = this.model || "claude-sonnet-4-5-20250929";
+    const model = this.model || "claude-sonnet-4-6";
     const url = `${this.endpoint}/v1/messages`;
 
     const body = {

--- a/src/config.js
+++ b/src/config.js
@@ -134,7 +134,7 @@ export const CoderConfigSchema = z.object({
   models: z
     .object({
       gemini: ModelEntrySchema.default({
-        model: "gemini-3-flash-preview",
+        model: "gemini-3.1-pro-preview",
         apiEndpoint: "https://generativelanguage.googleapis.com/v1beta",
         apiKeyEnv: "GEMINI_API_KEY",
       }),

--- a/src/ppcommit.js
+++ b/src/ppcommit.js
@@ -1044,7 +1044,7 @@ Respond with ONLY a JSON array. Each item:
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            model: config?.llmModel || "gemini-3-flash-preview",
+            model: config?.llmModel || "gemini-3.1-pro-preview",
             messages: [{ role: "user", content: prompt }],
             temperature: 0,
           }),

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -59,7 +59,7 @@ test("loadConfig: user config only merges with defaults", () => {
     const config = loadConfig(dir);
     assert.equal(config.verbose, true);
     assert.equal(config.models.claude, "claude-sonnet-4-5-20250929");
-    assert.equal(config.models.gemini, "gemini-2.5-flash"); // default preserved
+    assert.equal(config.models.gemini, "gemini-3.1-pro-preview"); // default preserved
   } finally {
     if (origXdg === undefined) delete process.env.XDG_CONFIG_HOME;
     else process.env.XDG_CONFIG_HOME = origXdg;


### PR DESCRIPTION
## Summary
- Update default Gemini model from `gemini-3-flash-preview` to `gemini-3.1-pro-preview` across config, example, ppcommit fallback, and test
- Update Claude fallback in api-agent from `claude-sonnet-4-5-20250929` to `claude-sonnet-4-6`

## Test plan
- [ ] `npx biome check src/ bin/ test/` passes
- [ ] `node --test` passes