### PR TITLE
fix(GH-101): replace invalid --sandbox-id with --resume latest for Gemini CLI

### DIFF
--- a/src/agents/cli-agent.js
+++ b/src/agents/cli-agent.js
@@ -135,8 +135,8 @@ export class CliAgent extends AgentAdapter {
       let cmd = modelName
         ? `gemini --yolo -m ${shellEscape(modelName)}`
         : "gemini --yolo";
-      if (sessionId) cmd += ` --sandbox-id ${shellEscape(sessionId)}`;
-      if (resumeId) cmd += ` --sandbox-id ${shellEscape(resumeId)}`;
+      // Gemini CLI doesn't support named sessions; use --resume for continuation
+      if (resumeId) cmd += " --resume latest";
       return heredocPipe(prompt, cmd);
     }
 

--- a/test/cli-agent.test.js
+++ b/test/cli-agent.test.js
@@ -27,18 +27,19 @@ function makeAgent(agentName, modelOverride) {
 const MALICIOUS = "'; touch /tmp/pwned; #";
 const ESCAPED_MALICIOUS = "''\\''; touch /tmp/pwned; #'";
 
-test("gemini: malicious sessionId is shell-escaped", () => {
+test("gemini: sessionId is ignored (no Gemini equivalent)", () => {
   const agent = makeAgent("gemini");
-  const cmd = agent._buildCommand("prompt", { sessionId: MALICIOUS });
-  assert.ok(cmd.includes(`--sandbox-id ${ESCAPED_MALICIOUS}`));
-  assert.ok(!cmd.includes(`--sandbox-id '; touch`));
+  const cmd = agent._buildCommand("prompt", { sessionId: "some-id" });
+  assert.ok(!cmd.includes("--sandbox-id"));
+  assert.ok(!cmd.includes("--session-id"));
+  assert.ok(!cmd.includes("--resume"));
 });
 
-test("gemini: malicious resumeId is shell-escaped", () => {
+test("gemini: resumeId maps to --resume latest", () => {
   const agent = makeAgent("gemini");
-  const cmd = agent._buildCommand("prompt", { resumeId: MALICIOUS });
-  assert.ok(cmd.includes(`--sandbox-id ${ESCAPED_MALICIOUS}`));
-  assert.ok(!cmd.includes(`--sandbox-id '; touch`));
+  const cmd = agent._buildCommand("prompt", { resumeId: "some-id" });
+  assert.ok(cmd.includes("--resume latest"));
+  assert.ok(!cmd.includes("--sandbox-id"));
 });
 
 test("gemini: malicious modelName is shell-escaped", () => {


### PR DESCRIPTION
## Summary

Fixes #101.

- Gemini CLI does not have a `--sandbox-id` flag — using it causes `Unknown arguments: sandbox-id` failures during planning and quality review steps
- `resumeId` now maps to `--resume latest` (Gemini's session continuation flag)
- `sessionId` is ignored for Gemini since it has no named-session equivalent
- Updated tests to reflect the corrected behavior

## Test plan

- [x] All 250 tests pass (`node --test test/*.test.js`)
- [x] Biome lint clean on changed files
- [ ] End-to-end: run a develop workflow with Gemini assigned to planner/reviewer roles — planning and quality review steps should no longer fail with `Unknown arguments`