### PR TITLE
docs: document dev/main branch workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,21 @@
 # Contributing
 
+## Branch model
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Stable releases — PRs from `dev` only |
+| `dev` | Integration branch — all contributions target here |
+
+**Workflow:**
+
+1. Fork or create a feature branch from `dev`
+2. Open a PR targeting `dev`
+3. Once merged, maintainers layer follow-up fixes if needed
+4. Periodically, `dev` is PR'd into `main` as a release
+
+Both `main` and `dev` are protected — no direct pushes, PRs required.
+
 ## Setup
 
 ```bash
@@ -13,7 +29,7 @@ npm install
 ```bash
 npm run lint          # biome check
 npm run format:check  # biome format
-npm test              # node --test (162 tests)
+npm test              # node --test
 npm audit --audit-level=high
 ```
 
@@ -29,11 +45,12 @@ This project uses `ppcommit` (tree-sitter AST-based) to enforce commit quality:
 
 ```bash
 coder ppcommit              # check all files
-coder ppcommit --base main  # check branch diff only
+coder ppcommit --base dev   # check branch diff only
 ```
 
 ## Pull request checklist
 
+- Target the `dev` branch (not `main`)
 - Keep changes focused and scoped to one concern
 - Add or update tests when behavior changes
 - Update README.md if user-facing behavior or config changes


### PR DESCRIPTION
## Summary

- Adds **Branch model** section to CONTRIBUTING.md explaining the `dev`/`main` split
- Updates PR checklist to say "Target the `dev` branch"
- Updates `ppcommit --base` example from `main` to `dev`

Reflects the new collaboration workflow where contributions merge into `dev`, fixes are layered on top, and `dev` is periodically PR'd into `main` for release.

## Test plan

- [x] Documentation-only change, no code impact