### PR TITLE
chore: sync package-lock.json with package.json bin field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,7 @@
         "zod": "^4.3.6"
       },
       "bin": {
-        "coder": "bin/coder.js",
-        "coder-mcp": "bin/coder-mcp.js"
+        "coder": "bin/coder.js"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.4"


### PR DESCRIPTION
## Summary

- Syncs `package-lock.json` to match `package.json` — removes stale `coder-mcp` bin entry that was already removed from `package.json`

## Test plan

- [x] `npx biome check` — clean
- [x] `node --test` — 250 tests pass, 0 failures