### PR TITLE
feat: Bug: fatal CLI agent errors are not detected on stderr — agent waits out full timeout before retry

### DIFF
--- a/src/agents/pool.js
+++ b/src/agents/pool.js
@@ -73,7 +73,11 @@ class RetryFallbackWrapper extends AgentAdapter {
         shouldRetry: (ctx) => {
           const name = ctx.error.name;
           if (name === "CommandTimeoutError") return false;
-          if (name === "CommandAuthError") return false;
+          if (
+            name === "CommandFatalStderrError" &&
+            ctx.error.category === "auth"
+          )
+            return false;
           if (name === "McpStartupError") return false;
           return true;
         },

--- a/src/machines/develop/implementation.machine.js
+++ b/src/machines/develop/implementation.machine.js
@@ -136,7 +136,11 @@ FORBIDDEN patterns:
         timeoutMs: ctx.config.workflow.timeouts.implementation,
       });
     } catch (err) {
-      if (err.name === "CommandAuthError" && state.claudeSessionId) {
+      if (
+        err.name === "CommandFatalStderrError" &&
+        err.category === "auth" &&
+        state.claudeSessionId
+      ) {
         ctx.log({
           event: "session_resume_failed",
           sessionId: state.claudeSessionId,

--- a/src/machines/develop/planning.machine.js
+++ b/src/machines/develop/planning.machine.js
@@ -221,7 +221,11 @@ Constraints:
             timeoutMs: ctx.config.workflow.timeouts.planning,
           });
         } catch (err) {
-          if (err.name === "CommandAuthError" && sessionOpts.resumeId) {
+          if (
+            err.name === "CommandFatalStderrError" &&
+            err.category === "auth" &&
+            sessionOpts.resumeId
+          ) {
             ctx.log({
               event: "session_resume_failed",
               sessionId: state.claudeSessionId,

--- a/src/machines/develop/quality-review.machine.js
+++ b/src/machines/develop/quality-review.machine.js
@@ -340,7 +340,11 @@ export default defineMachine({
               timeoutMs: ctx.config.workflow.timeouts.reviewRound,
             });
           } catch (err) {
-            if (err.name === "CommandAuthError" && reviewSessionOpts.resumeId) {
+            if (
+              err.name === "CommandFatalStderrError" &&
+              err.category === "auth" &&
+              reviewSessionOpts.resumeId
+            ) {
               ctx.log({
                 event: "session_resume_failed",
                 sessionId: state.reviewerSessionId,
@@ -398,7 +402,11 @@ export default defineMachine({
             timeoutMs: ctx.config.workflow.timeouts.programmerFix,
           });
         } catch (err) {
-          if (err.name === "CommandAuthError" && state.claudeSessionId) {
+          if (
+            err.name === "CommandFatalStderrError" &&
+            err.category === "auth" &&
+            state.claudeSessionId
+          ) {
             ctx.log({
               event: "session_resume_failed",
               sessionId: state.claudeSessionId,


### PR DESCRIPTION
# Issue: Bug: fatal CLI agent errors are not detected on stderr — agent waits out full timeout before retry

## Metadata
- Source: github
- Issue ID: #120
- Repo Root: /home/fcc/Programming/AITOOLS/coder

## Problem
When a CLI-backed agent (like Gemini, Claude, or Codex) encounters a fatal error, it often outputs a diagnostic message to stderr and then hangs in an internal retry loop. Because the `coder` agent does not inspect stderr for generic terminal patterns, it waits out the full subprocess timeout (often several minutes).

Closes #120