### PR TITLE
fix: start-lock configurable opts, missing await bug, narrowed scope

### DIFF
--- a/src/mcp/tools/workflows.js
+++ b/src/mcp/tools/workflows.js
@@ -540,244 +540,251 @@ export function registerWorkflowTools(server, defaultWorkspace) {
         }
 
         if (action === "start") {
-          return await withStartLock(ws, async () => {
-            // Cancel any active in-memory runs for this workspace
-            for (const [id, run] of activeRuns) {
-              if (run.workspace !== ws) continue;
-              const diskState = await loadLoopState(ws);
-              if (
-                ["completed", "failed", "cancelled"].includes(diskState.status)
-              ) {
+          const { nextRunId, initialAgent } = await withStartLock(
+            ws,
+            async () => {
+              // Cancel any active in-memory runs for this workspace
+              for (const [id, run] of activeRuns) {
+                if (run.workspace !== ws) continue;
+                const diskState = await loadLoopState(ws);
+                if (
+                  ["completed", "failed", "cancelled"].includes(
+                    diskState.status,
+                  )
+                ) {
+                  activeRuns.delete(id);
+                  workflowActors.delete(id);
+                  continue;
+                }
+                // Force-cancel the old run: set flag, kill agents, await exit
+                run.cancelToken.cancelled = true;
+                try {
+                  await run.agentPool?.killAll();
+                } catch {}
+                const actorEntry = workflowActors.get(id);
+                if (actorEntry?.workspace === ws) {
+                  actorEntry.actor.send({
+                    type: "CANCEL",
+                    at: new Date().toISOString(),
+                  });
+                }
+                await Promise.race([
+                  run.promise,
+                  new Promise((r) => setTimeout(r, 10_000)),
+                ]);
+                await markRunTerminalOnDisk(ws, id, workflow, "cancelled");
                 activeRuns.delete(id);
                 workflowActors.delete(id);
-                continue;
               }
-              // Force-cancel the old run: set flag, kill agents, await exit
-              run.cancelToken.cancelled = true;
-              try {
-                await run.agentPool?.killAll();
-              } catch {}
-              const actorEntry = workflowActors.get(id);
-              if (actorEntry?.workspace === ws) {
-                actorEntry.actor.send({
-                  type: "CANCEL",
-                  at: new Date().toISOString(),
-                });
-              }
-              await Promise.race([
-                run.promise,
-                new Promise((r) => setTimeout(r, 10_000)),
-              ]);
-              await markRunTerminalOnDisk(ws, id, workflow, "cancelled");
-              activeRuns.delete(id);
-              workflowActors.delete(id);
-            }
 
-            // Also check disk state — guards against restarts where activeRuns was cleared
-            {
-              const diskLoopState = await loadLoopState(ws);
-              if (
-                diskLoopState.status === "running" ||
-                diskLoopState.status === "paused"
-              ) {
-                // Mark stale or orphaned disk runs as failed so the new run can start
-                await markRunTerminalOnDisk(
-                  ws,
-                  diskLoopState.runId,
-                  workflow,
-                  "failed",
+              // Also check disk state — guards against restarts where activeRuns was cleared
+              {
+                const diskLoopState = await loadLoopState(ws);
+                if (
+                  diskLoopState.status === "running" ||
+                  diskLoopState.status === "paused"
+                ) {
+                  // Mark stale or orphaned disk runs as failed so the new run can start
+                  await markRunTerminalOnDisk(
+                    ws,
+                    diskLoopState.runId,
+                    workflow,
+                    "failed",
+                  );
+                }
+              }
+
+              const nextRunId = randomUUID().slice(0, 8);
+              const initialAgent = params.agentRoles?.issueSelector || "gemini";
+
+              // Preserve prior issueQueue so runDevelopLoop can merge terminal statuses
+              const priorLoopState = await loadLoopState(ws);
+
+              // Save initial loop state
+              await saveLoopState(ws, {
+                version: 1,
+                runId: nextRunId,
+                goal: params.goal,
+                status: "running",
+                projectFilter: params.projectFilter || null,
+                maxIssues: params.maxIssues || null,
+                issueQueue: priorLoopState.issueQueue || [],
+                currentIndex: 0,
+                currentStage: `${workflow}_starting`,
+                currentStageStartedAt: new Date().toISOString(),
+                activeAgent: initialAgent,
+                lastHeartbeatAt: new Date().toISOString(),
+                runnerPid: process.pid,
+                startedAt: new Date().toISOString(),
+                completedAt: null,
+              });
+
+              return { nextRunId, initialAgent };
+            },
+          );
+
+          startWorkflowActor({
+            workflow,
+            workspaceDir: ws,
+            runId: nextRunId,
+            goal: params.goal,
+            initialAgent,
+            currentStage: `${workflow}_starting`,
+          });
+
+          const cancelToken = { cancelled: false, paused: false };
+
+          // Build workflow context — agentRoles must be nested under workflow
+          const overrides = {};
+          if (params.agentRoles) {
+            overrides.workflow = { agentRoles: params.agentRoles };
+          }
+          const config = resolveConfig(ws, overrides);
+          const artifactsDir = path.join(ws, ".coder", "artifacts");
+          const scratchpadDir = path.join(ws, ".coder", "scratchpad");
+          await mkdir(path.join(ws, ".coder"), { recursive: true });
+          await mkdir(artifactsDir, { recursive: true });
+          await mkdir(scratchpadDir, { recursive: true });
+          ensureLogsDir(ws);
+
+          const log = makeJsonlLogger(ws, workflow, { runId: nextRunId });
+          const secrets = buildSecrets(resolvePassEnv(config));
+          const steeringContext = loadSteeringContext(ws);
+          const agentPool = new AgentPool({
+            config,
+            workspaceDir: ws,
+            verbose: config.verbose,
+            steeringContext,
+            runId: nextRunId,
+          });
+
+          // Store run entry with agentPool so cancel can kill agents
+          activeRuns.set(nextRunId, {
+            cancelToken,
+            agentPool,
+            workspace: ws,
+            promise: Promise.resolve(),
+            startedAt: new Date().toISOString(),
+          });
+
+          const workflowCtx = {
+            workspaceDir: ws,
+            repoPath: params.repoPath || ".",
+            config,
+            agentPool,
+            log,
+            cancelToken,
+            secrets,
+            artifactsDir,
+            scratchpadDir,
+            steeringContext,
+          };
+
+          // Fire and forget — run in background
+          const runPromise = (async () => {
+            try {
+              let result;
+              if (workflow === "develop") {
+                result = await runDevelopLoop(
+                  {
+                    goal: params.goal,
+                    projectFilter: params.projectFilter,
+                    maxIssues: params.maxIssues || 10,
+                    destructiveReset: params.destructiveReset,
+                    testCmd: params.testCmd,
+                    testConfigPath: params.testConfigPath,
+                    allowNoTests: params.allowNoTests,
+                    issueSource:
+                      params.issueSource || config.workflow.issueSource,
+                    localIssuesDir:
+                      params.localIssuesDir || config.workflow.localIssuesDir,
+                    ppcommitPreset: params.ppcommitPreset,
+                    issueIds: params.issueIds || [],
+                  },
+                  workflowCtx,
                 );
+              } else if (workflow === "research") {
+                result = await runResearchPipeline(
+                  {
+                    pointers: params.pointers,
+                    repoPath: params.repoPath,
+                    clarifications: params.clarifications,
+                    maxIssues: params.maxIssues || 6,
+                    iterations: params.iterations,
+                    webResearch: params.webResearch,
+                    validateIdeas: params.validateIdeas,
+                    validationMode: params.validationMode,
+                  },
+                  workflowCtx,
+                );
+              } else if (workflow === "design") {
+                result = await runDesignPipeline(
+                  {
+                    intent: params.designIntent || params.pointers || "",
+                    screenshotPaths: [],
+                    projectName: "",
+                    style: params.clarifications || "",
+                  },
+                  workflowCtx,
+                );
+              } else {
+                result = {
+                  status: "failed",
+                  error: `Unknown workflow: '${workflow}'.`,
+                };
               }
-            }
 
-            const nextRunId = randomUUID().slice(0, 8);
-            const initialAgent = params.agentRoles?.issueSelector || "gemini";
-
-            // Preserve prior issueQueue so runDevelopLoop can merge terminal statuses
-            const priorLoopState = loadLoopState(ws);
-
-            // Save initial loop state
-            await saveLoopState(ws, {
-              version: 1,
-              runId: nextRunId,
-              goal: params.goal,
-              status: "running",
-              projectFilter: params.projectFilter || null,
-              maxIssues: params.maxIssues || null,
-              issueQueue: priorLoopState.issueQueue || [],
-              currentIndex: 0,
-              currentStage: `${workflow}_starting`,
-              currentStageStartedAt: new Date().toISOString(),
-              activeAgent: initialAgent,
-              lastHeartbeatAt: new Date().toISOString(),
-              runnerPid: process.pid,
-              startedAt: new Date().toISOString(),
-              completedAt: null,
-            });
-
-            startWorkflowActor({
-              workflow,
-              workspaceDir: ws,
-              runId: nextRunId,
-              goal: params.goal,
-              initialAgent,
-              currentStage: `${workflow}_starting`,
-            });
-
-            const cancelToken = { cancelled: false, paused: false };
-
-            // Build workflow context — agentRoles must be nested under workflow
-            const overrides = {};
-            if (params.agentRoles) {
-              overrides.workflow = { agentRoles: params.agentRoles };
-            }
-            const config = resolveConfig(ws, overrides);
-            const artifactsDir = path.join(ws, ".coder", "artifacts");
-            const scratchpadDir = path.join(ws, ".coder", "scratchpad");
-            await mkdir(path.join(ws, ".coder"), { recursive: true });
-            await mkdir(artifactsDir, { recursive: true });
-            await mkdir(scratchpadDir, { recursive: true });
-            ensureLogsDir(ws);
-
-            const log = makeJsonlLogger(ws, workflow, { runId: nextRunId });
-            const secrets = buildSecrets(resolvePassEnv(config));
-            const steeringContext = loadSteeringContext(ws);
-            const agentPool = new AgentPool({
-              config,
-              workspaceDir: ws,
-              verbose: config.verbose,
-              steeringContext,
-              runId: nextRunId,
-            });
-
-            // Store run entry with agentPool so cancel can kill agents
-            activeRuns.set(nextRunId, {
-              cancelToken,
-              agentPool,
-              workspace: ws,
-              promise: Promise.resolve(),
-              startedAt: new Date().toISOString(),
-            });
-
-            const workflowCtx = {
-              workspaceDir: ws,
-              repoPath: params.repoPath || ".",
-              config,
-              agentPool,
-              log,
-              cancelToken,
-              secrets,
-              artifactsDir,
-              scratchpadDir,
-              steeringContext,
-            };
-
-            // Fire and forget — run in background
-            const runPromise = (async () => {
-              try {
-                let result;
-                if (workflow === "develop") {
-                  result = await runDevelopLoop(
-                    {
-                      goal: params.goal,
-                      projectFilter: params.projectFilter,
-                      maxIssues: params.maxIssues || 10,
-                      destructiveReset: params.destructiveReset,
-                      testCmd: params.testCmd,
-                      testConfigPath: params.testConfigPath,
-                      allowNoTests: params.allowNoTests,
-                      issueSource:
-                        params.issueSource || config.workflow.issueSource,
-                      localIssuesDir:
-                        params.localIssuesDir || config.workflow.localIssuesDir,
-                      ppcommitPreset: params.ppcommitPreset,
-                      issueIds: params.issueIds || [],
-                    },
-                    workflowCtx,
-                  );
-                } else if (workflow === "research") {
-                  result = await runResearchPipeline(
-                    {
-                      pointers: params.pointers,
-                      repoPath: params.repoPath,
-                      clarifications: params.clarifications,
-                      maxIssues: params.maxIssues || 6,
-                      iterations: params.iterations,
-                      webResearch: params.webResearch,
-                      validateIdeas: params.validateIdeas,
-                      validationMode: params.validationMode,
-                    },
-                    workflowCtx,
-                  );
-                } else if (workflow === "design") {
-                  result = await runDesignPipeline(
-                    {
-                      intent: params.designIntent || params.pointers || "",
-                      screenshotPaths: [],
-                      projectName: "",
-                      style: params.clarifications || "",
-                    },
-                    workflowCtx,
-                  );
-                } else {
-                  result = {
-                    status: "failed",
-                    error: `Unknown workflow: '${workflow}'.`,
-                  };
-                }
-
-                const finalStatus =
-                  result.status === "completed" ? "completed" : "failed";
-                const at = new Date().toISOString();
-                const actorEntry = workflowActors.get(nextRunId);
-                if (actorEntry) {
-                  if (finalStatus === "completed")
-                    actorEntry.actor.send({ type: "COMPLETE", at });
-                  else
-                    actorEntry.actor.send({
-                      type: "FAIL",
-                      at,
-                      error: result.error || "unknown",
-                    });
-                  actorEntry.actor.stop();
-                  workflowActors.delete(nextRunId);
-                }
-                activeRuns.delete(nextRunId);
-                await agentPool.killAll();
-              } catch (err) {
-                const at = new Date().toISOString();
-                const actorEntry = workflowActors.get(nextRunId);
-                if (actorEntry) {
+              const finalStatus =
+                result.status === "completed" ? "completed" : "failed";
+              const at = new Date().toISOString();
+              const actorEntry = workflowActors.get(nextRunId);
+              if (actorEntry) {
+                if (finalStatus === "completed")
+                  actorEntry.actor.send({ type: "COMPLETE", at });
+                else
                   actorEntry.actor.send({
                     type: "FAIL",
                     at,
-                    error: err.message,
+                    error: result.error || "unknown",
                   });
-                  actorEntry.actor.stop();
-                  workflowActors.delete(nextRunId);
-                }
-                await markRunTerminalOnDisk(ws, nextRunId, workflow, "failed");
-                activeRuns.delete(nextRunId);
-                await agentPool.killAll();
+                actorEntry.actor.stop();
+                workflowActors.delete(nextRunId);
               }
-            })();
+              activeRuns.delete(nextRunId);
+              await agentPool.killAll();
+            } catch (err) {
+              const at = new Date().toISOString();
+              const actorEntry = workflowActors.get(nextRunId);
+              if (actorEntry) {
+                actorEntry.actor.send({
+                  type: "FAIL",
+                  at,
+                  error: err.message,
+                });
+                actorEntry.actor.stop();
+                workflowActors.delete(nextRunId);
+              }
+              await markRunTerminalOnDisk(ws, nextRunId, workflow, "failed");
+              activeRuns.delete(nextRunId);
+              await agentPool.killAll();
+            }
+          })();
 
-            activeRuns.get(nextRunId).promise = runPromise;
+          activeRuns.get(nextRunId).promise = runPromise;
 
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: JSON.stringify({
-                    action,
-                    workflow,
-                    runId: nextRunId,
-                    status: "started",
-                  }),
-                },
-              ],
-            };
-          });
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  action,
+                  workflow,
+                  runId: nextRunId,
+                  status: "started",
+                }),
+              },
+            ],
+          };
         }
 
         // cancel/pause/resume require runId


### PR DESCRIPTION
## Summary
- **Bug fix**: Add missing `await` on `loadLoopState(ws)` that silently dropped the prior issue queue on every workflow restart (`priorLoopState.issueQueue` was always `undefined`)
- **Narrow lock scope**: Critical section now only covers cancel-loop + `saveLoopState`; actor creation, dir setup, config, agentPool, and fire-and-forget promise moved outside the lock
- **Configurable options**: Export `LOCK_DEFAULTS`, add optional `opts` third parameter to `withStartLock` for tunable timeouts/intervals; fully backward-compatible
- **Retry jitter**: `sleep(retryIntervalMs * (0.5 + Math.random()))` reduces contention under concurrent starts
- **Dynamic error message**: Interpolates actual `lockTimeoutMs` value instead of hardcoded `5000ms`

## Test plan
- [x] `npx biome check` — no lint issues
- [x] `node --test test/workflow-start-lock.test.js` — 10/10 pass, concurrent test ~400ms (was ~11s)
- [x] `node --test test/*.test.js` — 303/303 pass, no regressions