### PR TITLE
fix(ppcommit): handle irreparable fallback JSON safely

### DIFF
--- a/src/ppcommit.js
+++ b/src/ppcommit.js
@@ -960,7 +960,11 @@ function extractJsonArray(text) {
   const lastBracket = trimmed.lastIndexOf("]");
   if (firstBracket !== -1 && lastBracket !== -1 && lastBracket > firstBracket) {
     const candidate = trimmed.slice(firstBracket, lastBracket + 1);
-    return JSON.parse(jsonrepair(candidate));
+    try {
+      return JSON.parse(jsonrepair(candidate));
+    } catch {
+      return [];
+    }
   }
   return [];
 }

--- a/test/ppcommit.test.js
+++ b/test/ppcommit.test.js
@@ -89,6 +89,41 @@ test("ppcommit: does not crash when optional parsers are unavailable", async () 
   assert.equal(r.exitCode, 0);
 });
 
+test("ppcommit: irreparable LLM fallback JSON returns cleanly without extra retries", async () => {
+  const repo = makeRepo();
+  writeFileSync(path.join(repo, "a.js"), "const x = 1;\n", "utf8");
+
+  let calls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    calls++;
+    return {
+      ok: true,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              content: 'prefix [{"a":"\\uZZZZ"}] suffix',
+            },
+          },
+        ],
+      }),
+    };
+  };
+
+  try {
+    const r = await runPpcommitNative(repo, {
+      blockSecrets: false,
+      enableLlm: true,
+      llmApiKey: "test-key",
+    });
+    assert.equal(r.exitCode, 0);
+    assert.equal(calls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("ppcommit: detects staged new markdown files", async () => {
   const repo = makeRepo();
   mkdirSync(path.join(repo, "docs"), { recursive: true });


### PR DESCRIPTION
## Summary
- wrap fallback `JSON.parse(jsonrepair(candidate))` in `extractJsonArray` with `try/catch`
- return `[]` when fallback JSON remains irreparable
- add regression test that verifies malformed fallback JSON does not trigger retry loops

## Testing
- `node --test test/ppcommit.test.js`

Closes #140
