### PR TITLE
fix(claude): avoid nested session side effects in sub-agents

### DIFF
--- a/src/agents/cli-agent.js
+++ b/src/agents/cli-agent.js
@@ -175,7 +175,7 @@ export class CliAgent extends AgentAdapter {
     }
 
     if (this.name === "claude") {
-      let flags = "claude -p";
+      let flags = "claude -p --no-session-persistence";
       const claudeModel = resolveModelName(this.config.models.claude);
       if (claudeModel) {
         flags += ` --model ${shellEscape(claudeModel)}`;

--- a/src/host-sandbox.js
+++ b/src/host-sandbox.js
@@ -65,6 +65,13 @@ function mergeEnv(base, extra) {
   return { ...base, ...(extra || {}) };
 }
 
+function stripNestedClaudeEnv(env) {
+  const clean = { ...(env || {}) };
+  delete clean.CLAUDECODE;
+  delete clean.CLAUDE_CODE_ENTRYPOINT;
+  return clean;
+}
+
 function filterEnv(env) {
   const out = {};
   for (const key of SAFE_ENV_KEYS) {
@@ -85,20 +92,26 @@ export class HostSandboxProvider {
 
   async create(envs = {}, agentType = "default", workingDirectory) {
     const sandboxId = `host-${agentType}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const mergedEnv = stripNestedClaudeEnv(
+      mergeEnv(mergeEnv(filterEnv(process.env), this.baseEnv), envs),
+    );
     return new HostSandboxInstance({
       sandboxId,
       cwd: workingDirectory || this.defaultCwd,
-      env: mergeEnv(mergeEnv(filterEnv(process.env), this.baseEnv), envs),
+      env: mergedEnv,
       useSystemdRun: this.useSystemdRun,
     });
   }
 
   async resume(sandboxId) {
     // "Resume" is best-effort for host execution: return a fresh instance using current env/cwd.
+    const mergedEnv = stripNestedClaudeEnv(
+      mergeEnv(filterEnv(process.env), this.baseEnv),
+    );
     return new HostSandboxInstance({
       sandboxId,
       cwd: this.defaultCwd,
-      env: mergeEnv(filterEnv(process.env), this.baseEnv),
+      env: mergedEnv,
       useSystemdRun: this.useSystemdRun,
     });
   }

--- a/test/cli-agent.test.js
+++ b/test/cli-agent.test.js
@@ -64,6 +64,12 @@ test("claude: malicious sessionId is shell-escaped", () => {
   assert.ok(!cmd.includes(`--session-id '; touch`));
 });
 
+test("claude: command includes --no-session-persistence", () => {
+  const agent = makeAgent("claude");
+  const cmd = agent._buildCommand("prompt", {});
+  assert.ok(cmd.includes("--no-session-persistence"));
+});
+
 test("claude: malicious resumeId is shell-escaped", () => {
   const agent = makeAgent("claude");
   const cmd = agent._buildCommand("prompt", { resumeId: MALICIOUS });

--- a/test/host-sandbox.test.js
+++ b/test/host-sandbox.test.js
@@ -108,3 +108,21 @@ test("host sandbox does not inherit sensitive env vars from process.env", async 
     }
   }
 });
+
+test("host sandbox strips CLAUDECODE and CLAUDE_CODE_ENTRYPOINT from final env", async () => {
+  const provider = new HostSandboxProvider({
+    baseEnv: {
+      CLAUDECODE: "1",
+      CLAUDE_CODE_ENTRYPOINT: "nested",
+    },
+  });
+  const sandbox = await provider.create({
+    CLAUDECODE: "1",
+    CLAUDE_CODE_ENTRYPOINT: "nested",
+  });
+  const result = await sandbox.commands.run(`printenv || true`, {
+    timeoutMs: 5000,
+  });
+  assert.ok(!/CLAUDECODE=/.test(result.stdout));
+  assert.ok(!/CLAUDE_CODE_ENTRYPOINT=/.test(result.stdout));
+});


### PR DESCRIPTION
## Summary
- add `--no-session-persistence` to Claude CLI invocation in `CliAgent`
- strip `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` from final spawned env in `HostSandboxProvider`
- add command construction and env-stripping regression tests

## Testing
- `node --test test/cli-agent.test.js`
- `node --test test/host-sandbox.test.js`

Closes #144
