### PR TITLE
fix(pr): extract remote host detection and include GITLAB_TOKEN

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -210,6 +210,7 @@ export const SandboxConfigSchema = z.object({
       "CLAUDE_CODE_OAUTH_TOKEN",
       "OPENAI_API_KEY",
       "GITHUB_TOKEN",
+      "GITLAB_TOKEN",
       "LINEAR_API_KEY",
     ]),
   passEnvPatterns: z.array(z.string()).default([]),

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -43,6 +43,27 @@ export function detectDefaultBranch(repoDir) {
   return mainCheck.status === 0 ? "main" : "master";
 }
 
+/**
+ * Detect repository hosting type from remote URL.
+ *
+ * @param {string} repoDir - Path to the git repository
+ * @param {string} [remoteName="origin"] - Remote name to inspect
+ * @returns {"github" | "gitlab"}
+ */
+export function detectRemoteType(repoDir, remoteName = "origin") {
+  const origin = spawnSync("git", ["remote", "get-url", remoteName], {
+    cwd: repoDir,
+    encoding: "utf8",
+  });
+  if (origin.status !== 0) return "github";
+  const url = (origin.stdout || "").trim();
+  const httpsMatch = url.match(/^https?:\/\/([^/:]+)/i);
+  const sshMatch = url.match(/^[^@]+@([^:]+):/);
+  const host = (httpsMatch?.[1] || sshMatch?.[1] || "").toLowerCase();
+  if (host.includes("gitlab")) return "gitlab";
+  return "github";
+}
+
 const DEFAULT_PASS_ENV = [
   "GOOGLE_API_KEY",
   "GEMINI_API_KEY",
@@ -50,6 +71,7 @@ const DEFAULT_PASS_ENV = [
   "CLAUDE_CODE_OAUTH_TOKEN",
   "OPENAI_API_KEY",
   "GITHUB_TOKEN",
+  "GITLAB_TOKEN",
   "LINEAR_API_KEY",
 ];
 

--- a/src/machines/develop/pr-creation.machine.js
+++ b/src/machines/develop/pr-creation.machine.js
@@ -4,6 +4,7 @@ import { z } from "zod";
 import {
   buildPrBodyFromIssue,
   computeGitWorktreeFingerprint,
+  detectRemoteType,
   runPpcommit,
   stripAgentNoise,
 } from "../../helpers.js";
@@ -18,7 +19,7 @@ import { artifactPaths, ensureBranch, resolveRepoRoot } from "./_shared.js";
 export default defineMachine({
   name: "develop.pr_creation",
   description:
-    "Create pull request: commit changes, push to remote, create PR via gh CLI.",
+    "Create pull request: commit changes, push to remote, create PR/MR via gh or glab.",
   inputSchema: z.object({
     type: z.string().default("feat"),
     semanticName: z.string().default(""),
@@ -111,12 +112,8 @@ export default defineMachine({
       : state.branch;
     const baseBranch = input.base || state.baseBranch || null;
 
-    // Detect GitLab remote
-    const remoteResult = spawnSync("git", ["remote", "get-url", "origin"], {
-      cwd: repoRoot,
-      encoding: "utf8",
-    });
-    const isGitLab = /gitlab/i.test((remoteResult.stdout || "").trim());
+    // Detect hosting platform from origin remote URL.
+    const isGitLab = detectRemoteType(repoRoot) === "gitlab";
 
     // Push to remote
     const push = spawnSync(

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -393,6 +393,7 @@ test("CoderConfigSchema: sandbox.passEnv defaults to known API keys", () => {
   assert.ok(config.sandbox.passEnv.includes("GEMINI_API_KEY"));
   assert.ok(config.sandbox.passEnv.includes("ANTHROPIC_API_KEY"));
   assert.ok(config.sandbox.passEnv.includes("GITHUB_TOKEN"));
+  assert.ok(config.sandbox.passEnv.includes("GITLAB_TOKEN"));
 });
 
 test("CoderConfigSchema: sandbox.passEnvPatterns defaults to empty", () => {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -8,6 +8,7 @@ import { SandboxConfigSchema } from "../src/config.js";
 import {
   buildPrBodyFromIssue,
   buildSecretsWithFallback,
+  detectRemoteType,
   extractGeminiPayloadJson,
   extractJson,
   formatCommandFailure,
@@ -99,6 +100,29 @@ test("resolvePassEnv returns schema defaults when config has no sandbox", () => 
   const defaults = SandboxConfigSchema.parse({});
   const result = resolvePassEnv({});
   assert.deepEqual(result, defaults.passEnv);
+  assert.ok(result.includes("GITLAB_TOKEN"));
+});
+
+test("detectRemoteType identifies GitLab HTTPS remotes", () => {
+  const { repoDir } = setupGitRepo({ "a.txt": "a\n" });
+  const setOrigin = spawnSync(
+    "git",
+    ["remote", "add", "origin", "https://gitlab.com/acme/repo.git"],
+    { cwd: repoDir, encoding: "utf8" },
+  );
+  assert.equal(setOrigin.status, 0);
+  assert.equal(detectRemoteType(repoDir), "gitlab");
+});
+
+test("detectRemoteType identifies GitHub SSH remotes", () => {
+  const { repoDir } = setupGitRepo({ "a.txt": "a\n" });
+  const setOrigin = spawnSync(
+    "git",
+    ["remote", "add", "origin", "git@github.com:acme/repo.git"],
+    { cwd: repoDir, encoding: "utf8" },
+  );
+  assert.equal(setOrigin.status, 0);
+  assert.equal(detectRemoteType(repoDir), "github");
 });
 
 test("resolvePassEnv returns config sandbox.passEnv when set", () => {


### PR DESCRIPTION
## Summary
- add `detectRemoteType(repoDir)` helper for host detection from git remote URL
- use `detectRemoteType` in PR creation instead of inline regex logic
- include `GITLAB_TOKEN` in default sandbox pass-through env lists
- add helper/config regression tests for remote detection and default env keys

## Testing
- `node --test test/helpers.test.js test/config.test.js`
- `node --input-type=module -e "import('./src/machines/develop/pr-creation.machine.js'); console.log('ok')"`

Closes #145
