### PR TITLE
fix(workflow): serialize starts with namespaced lock and blocked response

### DIFF
--- a/src/mcp/tools/workflows.js
+++ b/src/mcp/tools/workflows.js
@@ -540,9 +540,9 @@ export function registerWorkflowTools(server, defaultWorkspace) {
         }
 
         if (action === "start") {
-          const { nextRunId, initialAgent } = await withStartLock(
-            ws,
-            async () => {
+          let startContext;
+          try {
+            startContext = await withStartLock(ws, async () => {
               // Cancel any active in-memory runs for this workspace
               for (const [id, run] of activeRuns) {
                 if (run.workspace !== ws) continue;
@@ -620,8 +620,26 @@ export function registerWorkflowTools(server, defaultWorkspace) {
               });
 
               return { nextRunId, initialAgent };
-            },
-          );
+            });
+          } catch (err) {
+            if (err?.code === "WORKFLOW_START_LOCK_BUSY") {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({
+                      action,
+                      workflow,
+                      status: "blocked",
+                      reason: "workflow_start_lock_busy",
+                    }),
+                  },
+                ],
+              };
+            }
+            throw err;
+          }
+          const { nextRunId, initialAgent } = startContext;
 
           startWorkflowActor({
             workflow,

--- a/src/state/start-lock.js
+++ b/src/state/start-lock.js
@@ -20,7 +20,7 @@ export const LOCK_DEFAULTS = {
 };
 
 export function lockPathFor(workspaceDir) {
-  return path.join(workspaceDir, ".coder", "start.lock");
+  return path.join(workspaceDir, ".coder", "locks", "workflow-start.lock");
 }
 
 function sleep(ms) {
@@ -78,9 +78,11 @@ async function acquireStartLock(workspaceDir, opts) {
       await sleep(retryIntervalMs * (0.5 + Math.random()));
     }
   }
-  throw new Error(
+  const err = new Error(
     `workflow start lock busy: could not acquire lock within ${lockTimeoutMs}ms`,
   );
+  err.code = "WORKFLOW_START_LOCK_BUSY";
+  throw err;
 }
 
 function releaseLock(lockPath, token) {

--- a/test/workflow-start-lock.test.js
+++ b/test/workflow-start-lock.test.js
@@ -19,7 +19,7 @@ import {
 
 function makeTmpDir() {
   const dir = mkdtempSync(path.join(os.tmpdir(), "coder-start-lock-"));
-  mkdirSync(path.join(dir, ".coder"), { recursive: true });
+  mkdirSync(path.join(dir, ".coder", "locks"), { recursive: true });
   return dir;
 }
 
@@ -48,9 +48,14 @@ test("concurrent starts: second caller gets lock-busy error", async () => {
   );
   // Give the first call time to acquire
   await new Promise((r) => setTimeout(r, 50));
-  await assert.rejects(() => withStartLock(ws, async () => "second", opts), {
-    message: /workflow start lock busy/,
-  });
+  await assert.rejects(
+    () => withStartLock(ws, async () => "second", opts),
+    (err) => {
+      assert.match(err.message, /workflow start lock busy/);
+      assert.equal(err.code, "WORKFLOW_START_LOCK_BUSY");
+      return true;
+    },
+  );
   // Clean up the slow holder
   const result = await slow;
   assert.equal(result, "first");
@@ -175,4 +180,13 @@ test("LOCK_DEFAULTS exports expected keys", () => {
   assert.ok(LOCK_DEFAULTS.staleLockMs > 0);
   assert.ok(LOCK_DEFAULTS.retryIntervalMs > 0);
   assert.ok(LOCK_DEFAULTS.corruptFileMinAgeMs > 0);
+});
+
+test("lockPathFor uses namespaced workflow start lock path", () => {
+  const ws = makeTmpDir();
+  assert.equal(
+    lockPathFor(ws),
+    path.join(ws, ".coder", "locks", "workflow-start.lock"),
+  );
+  rmSync(ws, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- move workflow start lock file to `.coder/locks/workflow-start.lock`
- keep stale-lock eviction and timeout behavior intact
- add lock-busy error code (`WORKFLOW_START_LOCK_BUSY`) for callers
- return structured `status: "blocked"` from `coder_workflow start` when lock cannot be acquired in time
- update lock tests for path and lock-busy code behavior

## Testing
- `node --test test/workflow-start-lock.test.js`
- `node --input-type=module -e "import('./src/mcp/tools/workflows.js'); console.log('ok')"`

Closes #146
