### PR TITLE
fix(ci): set git config in tests and bump vulnerable deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -670,12 +670,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
-      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -882,9 +882,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/test/repro-gh-118.test.js
+++ b/test/repro-gh-118.test.js
@@ -12,10 +12,10 @@ function makeTmpWorkspace() {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "gh118-"));
   mkdirSync(path.join(tmp, ".coder", "artifacts"), { recursive: true });
   mkdirSync(path.join(tmp, ".coder", "logs"), { recursive: true });
-  execSync("git init && git commit --allow-empty -m init", {
-    cwd: tmp,
-    stdio: "ignore",
-  });
+  execSync(
+    'git init && git config user.email "test@test" && git config user.name "test" && git commit --allow-empty -m init',
+    { cwd: tmp, stdio: "ignore" },
+  );
   return tmp;
 }
 


### PR DESCRIPTION
## Summary
- Fix 4 failing tests in `test/repro-gh-118.test.js` — `git commit --allow-empty` fails in CI because GitHub Actions runners have no global `user.name`/`user.email`. Added local git config in `makeTmpWorkspace()`.
- Run `npm audit fix` to resolve 3 high-severity vulnerabilities:
  - `hono` 4.12.0 → 4.12.7 (GHSA-xh87, GHSA-5pq2, GHSA-p6xx, GHSA-q5qw)
  - `@hono/node-server` 1.19.9 → 1.19.11 (GHSA-wc8c)
  - `express-rate-limit` 8.2.1 → 8.3.1 (GHSA-46wh)

This supersedes dependabot PRs #178, #179, and #184 (same bumps, plus newer patch versions).

## Test plan
- [x] All 319 tests pass locally (`npm test`)
- [x] `npm audit --audit-level=high` returns 0 vulnerabilities
- [x] `biome check` clean
- [ ] CI passes on this branch