### PR TITLE
fix(security): resolve symlinks in workspace and scratchpad boundary checks

### DIFF
--- a/src/mcp/workspace.js
+++ b/src/mcp/workspace.js
@@ -37,5 +37,9 @@ export function resolveWorkspaceForMcp(workspace, defaultWorkspace) {
         "Set CODER_ALLOW_ANY_WORKSPACE=1 to allow arbitrary paths.",
     );
   }
-  return targetPath;
+  try {
+    return realpathSync(targetPath);
+  } catch {
+    return targetPath;
+  }
 }

--- a/src/state/persistence.js
+++ b/src/state/persistence.js
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import {
   access,
   appendFile,
@@ -51,7 +52,14 @@ CREATE TABLE IF NOT EXISTS scratchpad_files (
   }
 
   _relPath(absPath) {
-    const rel = path.relative(this.workspaceDir, absPath);
+    let realBase, realTarget;
+    try {
+      realBase = realpathSync(this.workspaceDir);
+      realTarget = realpathSync(absPath);
+    } catch {
+      return null;
+    }
+    const rel = path.relative(realBase, realTarget);
     if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) return null;
     return rel;
   }

--- a/test/mcp-workspace.test.js
+++ b/test/mcp-workspace.test.js
@@ -1,5 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -83,6 +89,20 @@ test("resolveWorkspaceForMcp allows non-existent child path inside root", () => 
   try {
     const resolved = resolveWorkspaceForMcp(target, root);
     assert.equal(resolved, path.resolve(target));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("resolveWorkspaceForMcp returns resolved realpath for symlink inside root", () => {
+  const root = makeDir("coder-mcp-root-");
+  const realSub = path.join(root, "real-sub");
+  mkdirSync(realSub, { recursive: true });
+  const link = path.join(root, "link-to-sub");
+  symlinkSync(realSub, link, "dir");
+  try {
+    const resolved = resolveWorkspaceForMcp(link, root);
+    assert.equal(resolved, realpathSync(realSub));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/persistence.test.js
+++ b/test/persistence.test.js
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { ScratchpadPersistence } from "../src/state/persistence.js";
+
+function makeTmp(prefix) {
+  return mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+test("_relPath rejects symlink that escapes workspace", () => {
+  const workspace = makeTmp("coder-persist-ws-");
+  const outside = makeTmp("coder-persist-out-");
+  const outsideFile = path.join(outside, "secret.txt");
+  writeFileSync(outsideFile, "secret", "utf8");
+
+  const link = path.join(workspace, "evil-link.txt");
+  symlinkSync(outsideFile, link);
+
+  const sp = new ScratchpadPersistence({
+    workspaceDir: workspace,
+    scratchpadDir: path.join(workspace, ".coder", "scratchpad"),
+    sqlitePath: path.join(workspace, ".coder", "scratchpad.db"),
+    sqliteSync: false,
+  });
+
+  try {
+    assert.equal(sp._relPath(link), null, "symlink escape should return null");
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test("_relPath accepts file inside workspace", () => {
+  const workspace = makeTmp("coder-persist-ws-");
+  const innerFile = path.join(workspace, "notes.md");
+  writeFileSync(innerFile, "ok", "utf8");
+
+  const sp = new ScratchpadPersistence({
+    workspaceDir: workspace,
+    scratchpadDir: path.join(workspace, ".coder", "scratchpad"),
+    sqlitePath: path.join(workspace, ".coder", "scratchpad.db"),
+    sqliteSync: false,
+  });
+
+  try {
+    assert.equal(sp._relPath(innerFile), "notes.md");
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("_relPath returns null for non-existent file", () => {
+  const workspace = makeTmp("coder-persist-ws-");
+
+  const sp = new ScratchpadPersistence({
+    workspaceDir: workspace,
+    scratchpadDir: path.join(workspace, ".coder", "scratchpad"),
+    sqlitePath: path.join(workspace, ".coder", "scratchpad.db"),
+    sqliteSync: false,
+  });
+
+  try {
+    assert.equal(sp._relPath(path.join(workspace, "does-not-exist.md")), null);
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- **#160**: `resolveWorkspaceForMcp` validated the resolved realpath but returned the unresolved symlink to callers. Now returns `realpathSync(targetPath)` for existing paths (falls back to original for non-existent paths where the parent was validated).
- **#169**: `ScratchpadPersistence._relPath` used `path.relative()` on raw strings without resolving symlinks, allowing a symlink inside the workspace to bypass the boundary check. Now resolves both paths via `realpathSync` before comparison.
- **#173**: Closed — `sqlEscape()` correctly handles SQLite string literal escaping (doubles `'`, strips NUL). Not a real SQL injection vector.

Closes #160, closes #169

## Test plan
- [x] New test: symlink inside root returns resolved realpath (`mcp-workspace.test.js`)
- [x] New test: `_relPath` rejects symlink escaping workspace (`persistence.test.js`)
- [x] New test: `_relPath` accepts file inside workspace
- [x] New test: `_relPath` returns null for non-existent file
- [x] All 323 tests pass, biome clean
- [ ] CI passes