### PR TITLE
fix: resolve four medium-severity bugs (#161, #163, #164, #172)

### DIFF
--- a/src/logging.js
+++ b/src/logging.js
@@ -67,6 +67,11 @@ export function makeJsonlLogger(workspaceDir, name, { runId = "" } = {}) {
   ensureLogsDir(workspaceDir);
   const p = path.join(logsDir(workspaceDir), `${name}.jsonl`);
 
+  const prev = openStreams.get(p);
+  if (prev) {
+    prev.end();
+  }
+
   const stream = createWriteStream(p, { flags: "a" });
   stream.on("error", (err) => {
     process.stderr.write(`Logger error (${name}): ${err.message}\n`);

--- a/src/mcp/tools/steering.js
+++ b/src/mcp/tools/steering.js
@@ -37,6 +37,7 @@ export function registerSteeringTools(server, defaultWorkspace) {
       },
     },
     async ({ workspace, force }) => {
+      let pool = null;
       try {
         const ws = resolveWorkspaceForMcp(workspace, defaultWorkspace);
         const config = resolveConfig(ws);
@@ -58,7 +59,7 @@ export function registerSteeringTools(server, defaultWorkspace) {
 
         // Use gemini agent for generation (fast, cheap)
         const secrets = buildSecrets(resolvePassEnv(config));
-        const pool = new AgentPool({
+        pool = new AgentPool({
           config,
           workspaceDir: ws,
           verbose: false,
@@ -72,7 +73,6 @@ export function registerSteeringTools(server, defaultWorkspace) {
         });
 
         if (!result?.stdout) {
-          await pool.killAll();
           return {
             content: [
               {
@@ -87,7 +87,6 @@ export function registerSteeringTools(server, defaultWorkspace) {
         const parsed = parseSteeringResponse(result.stdout);
         const sections = Object.keys(parsed);
         if (sections.length === 0) {
-          await pool.killAll();
           return {
             content: [
               {
@@ -100,7 +99,6 @@ export function registerSteeringTools(server, defaultWorkspace) {
         }
 
         const written = writeSteeringFiles(ws, parsed);
-        await pool.killAll();
 
         return {
           content: [
@@ -120,6 +118,8 @@ export function registerSteeringTools(server, defaultWorkspace) {
           ],
           isError: true,
         };
+      } finally {
+        if (pool) await pool.killAll();
       }
     },
   );
@@ -144,11 +144,12 @@ export function registerSteeringTools(server, defaultWorkspace) {
       },
     },
     async ({ workspace }) => {
+      let pool = null;
       try {
         const ws = resolveWorkspaceForMcp(workspace, defaultWorkspace);
         const config = resolveConfig(ws);
         const secrets = buildSecrets(resolvePassEnv(config));
-        const pool = new AgentPool({
+        pool = new AgentPool({
           config,
           workspaceDir: ws,
           verbose: false,
@@ -162,7 +163,6 @@ export function registerSteeringTools(server, defaultWorkspace) {
         });
 
         if (!result?.stdout) {
-          await pool.killAll();
           return {
             content: [
               {
@@ -177,7 +177,6 @@ export function registerSteeringTools(server, defaultWorkspace) {
         const parsed = parseSteeringResponse(result.stdout);
         const sections = Object.keys(parsed);
         if (sections.length === 0) {
-          await pool.killAll();
           return {
             content: [
               {
@@ -190,7 +189,6 @@ export function registerSteeringTools(server, defaultWorkspace) {
         }
 
         const written = writeSteeringFiles(ws, parsed);
-        await pool.killAll();
 
         return {
           content: [
@@ -210,6 +208,8 @@ export function registerSteeringTools(server, defaultWorkspace) {
           ],
           isError: true,
         };
+      } finally {
+        if (pool) await pool.killAll();
       }
     },
   );

--- a/src/mcp/tools/workflows.js
+++ b/src/mcp/tools/workflows.js
@@ -676,14 +676,7 @@ export function registerWorkflowTools(server, defaultWorkspace) {
             runId: nextRunId,
           });
 
-          // Store run entry with agentPool so cancel can kill agents
-          activeRuns.set(nextRunId, {
-            cancelToken,
-            agentPool,
-            workspace: ws,
-            promise: Promise.resolve(),
-            startedAt: new Date().toISOString(),
-          });
+          const runStartedAt = new Date().toISOString();
 
           const workflowCtx = {
             workspaceDir: ws,
@@ -788,7 +781,14 @@ export function registerWorkflowTools(server, defaultWorkspace) {
             }
           })();
 
-          activeRuns.get(nextRunId).promise = runPromise;
+          // Store run entry with real promise so cancel can await it
+          activeRuns.set(nextRunId, {
+            cancelToken,
+            agentPool,
+            workspace: ws,
+            promise: runPromise,
+            startedAt: runStartedAt,
+          });
 
           return {
             content: [

--- a/src/state/workflow-state.js
+++ b/src/state/workflow-state.js
@@ -17,8 +17,18 @@ import {
 
 const WORKFLOW_STATE_SCHEMA_VERSION = 2;
 
-let _writeChain = Promise.resolve();
-let _sqliteWriteChain = Promise.resolve();
+/** @type {Map<string, Promise<void>>} */
+const _writeChains = new Map();
+/** @type {Map<string, Promise<void>>} */
+const _sqliteWriteChains = new Map();
+
+function getWriteChain(key) {
+  return _writeChains.get(key) || Promise.resolve();
+}
+
+function setWriteChain(key, promise) {
+  _writeChains.set(key, promise);
+}
 
 function nowIso() {
   return new Date().toISOString();
@@ -67,10 +77,11 @@ ON CONFLICT(run_id) DO UPDATE SET
 
 async function persistSnapshotToSqlite(sqlitePath, payload) {
   if (!sqlitePath || !sqliteAvailable()) return;
-  _sqliteWriteChain = _sqliteWriteChain
+  const chain = (_sqliteWriteChains.get(sqlitePath) || Promise.resolve())
     .then(() => _persistSnapshotToSqliteInner(sqlitePath, payload))
     .catch(() => {});
-  await _sqliteWriteChain;
+  _sqliteWriteChains.set(sqlitePath, chain);
+  await chain;
 }
 
 async function fileExists(p) {
@@ -112,12 +123,13 @@ export async function saveWorkflowSnapshot(
     updatedAt: nowIso(),
   };
   let writeErr;
-  _writeChain = _writeChain
+  const chain = getWriteChain(workspaceDir)
     .then(() => atomicWriteJson(statePath, payload))
     .catch((e) => {
       writeErr = e;
     });
-  await _writeChain;
+  setWriteChain(workspaceDir, chain);
+  await chain;
   if (writeErr) throw writeErr;
   await persistSnapshotToSqlite(sqlitePath, payload);
   return payload;
@@ -146,12 +158,13 @@ export async function saveWorkflowTerminalState(
     updatedAt: nowIso(),
   };
   let writeErr;
-  _writeChain = _writeChain
+  const chain = getWriteChain(workspaceDir)
     .then(() => atomicWriteJson(statePath, payload))
     .catch((e) => {
       writeErr = e;
     });
-  await _writeChain;
+  setWriteChain(workspaceDir, chain);
+  await chain;
   if (writeErr) throw writeErr;
   await persistSnapshotToSqlite(sqlitePath, payload);
   return payload;
@@ -351,12 +364,13 @@ export async function saveLoopState(
     } catch {}
   }
   let writeErr;
-  _writeChain = _writeChain
+  const chain = getWriteChain(workspaceDir)
     .then(() => atomicWriteJson(p, loopState))
     .catch((e) => {
       writeErr = e;
     });
-  await _writeChain;
+  setWriteChain(workspaceDir, chain);
+  await chain;
   if (writeErr) throw writeErr;
 }
 
@@ -510,11 +524,12 @@ export async function loadState(workspaceDir) {
 export async function saveState(workspaceDir, state) {
   const p = statePathFor(workspaceDir);
   let writeErr;
-  _writeChain = _writeChain
+  const chain = getWriteChain(workspaceDir)
     .then(() => atomicWriteJson(p, state))
     .catch((e) => {
       writeErr = e;
     });
-  await _writeChain;
+  setWriteChain(workspaceDir, chain);
+  await chain;
   if (writeErr) throw writeErr;
 }

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -34,6 +34,23 @@ test("makeJsonlLogger writes redacted payloads", async () => {
   assert.doesNotMatch(content, /topsecret|alsosecret/);
 });
 
+test("makeJsonlLogger closes previous stream when called twice with same name", async () => {
+  const ws = mkdtempSync(path.join(os.tmpdir(), "coder-logging-dup-"));
+  const logger1 = makeJsonlLogger(ws, "agent");
+  logger1({ event: "first" });
+
+  // Create second logger with same name — should close the first stream
+  const logger2 = makeJsonlLogger(ws, "agent");
+  logger2({ event: "second" });
+  await closeAllLoggers();
+
+  const content = readFileSync(path.join(logsDir(ws), "agent.jsonl"), "utf8");
+  const lines = content.trim().split("\n");
+  assert.ok(lines.length >= 2, "both events should be written");
+  assert.match(lines[0], /first/);
+  assert.match(lines[1], /second/);
+});
+
 test("sanitizeLogEvent redacts nested objects, arrays, and query tokens", () => {
   const event = sanitizeLogEvent({
     nested: { authorization: "Bearer supersecretvalue" },


### PR DESCRIPTION
## Summary
- **#161** (race condition): `activeRuns.set()` now happens after the IIFE `runPromise` is defined, so the entry gets the real promise instead of a placeholder `Promise.resolve()`
- **#172** (agent pool leak): Both `coder_steering_generate` and `coder_steering_update` now use `finally { if (pool) await pool.killAll() }` to guarantee cleanup even when `agent.execute()` throws
- **#163** (logger resource leak): `makeJsonlLogger` now calls `.end()` on the previous WriteStream before creating a new one when called twice with the same log name
- **#164** (shared write chain): Replaced module-level `_writeChain` / `_sqliteWriteChain` with per-workspace `Map`s so concurrent writes to different workspaces don't serialize through a single global chain

Closes #161, closes #163, closes #164, closes #172

## Test plan
- [x] New test: `makeJsonlLogger` closes previous stream on double-call (`logging.test.js`)
- [x] All 324 tests pass, biome clean
- [ ] CI passes