### PR TITLE
fix: resolve remaining low-severity bugs (#162, #165, #167, #171)

### DIFF
--- a/src/agents/pool.js
+++ b/src/agents/pool.js
@@ -283,13 +283,10 @@ export class AgentPool {
     // Invalidate repo-scoped agents since cwd changed — kill before removing
     const stale = [];
     for (const [key, agent] of this._agents) {
-      const parts = key.split(":");
-      // cli agents keyed as cli:name:cwd — kill those pointing at a different repo root
-      if (
-        parts[0] === "cli" &&
-        parts[2] !== repoRoot &&
-        parts[2] !== this.workspaceDir
-      ) {
+      // cli agents keyed as cli:name:cwd — extract cwd safely (may contain colons)
+      if (!key.startsWith("cli:")) continue;
+      const cwd = key.slice(key.indexOf(":", 4) + 1);
+      if (cwd !== repoRoot && cwd !== this.workspaceDir) {
         stale.push({ key, agent });
       }
     }

--- a/src/mcp/resources.js
+++ b/src/mcp/resources.js
@@ -1,11 +1,17 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { loopStatePathFor, statePathFor } from "../state/workflow-state.js";
 import { loadSteeringContext } from "../steering.js";
 
-function findLatestScratchpadFile(scratchpadDir) {
-  if (!existsSync(scratchpadDir)) return null;
+function tryReadFile(filePath, fallback) {
+  try {
+    return readFileSync(filePath, "utf8");
+  } catch {
+    return fallback;
+  }
+}
 
+function findLatestScratchpadFile(scratchpadDir) {
   /** @type {{ path: string, mtimeMs: number } | null} */
   let latest = null;
   const stack = [scratchpadDir];
@@ -47,127 +53,69 @@ export function registerResources(server, defaultWorkspace) {
       description:
         "Current .coder/state.json — workflow state including steps completed, selected issue, and branch",
     },
-    async () => {
-      const statePath = statePathFor(defaultWorkspace);
-      if (!existsSync(statePath)) {
-        return {
-          contents: [
-            { uri: "coder://state", mimeType: "application/json", text: "{}" },
-          ],
-        };
-      }
-      return {
-        contents: [
-          {
-            uri: "coder://state",
-            mimeType: "application/json",
-            text: readFileSync(statePath, "utf8"),
-          },
-        ],
-      };
-    },
+    async () => ({
+      contents: [
+        {
+          uri: "coder://state",
+          mimeType: "application/json",
+          text: tryReadFile(statePathFor(defaultWorkspace), "{}"),
+        },
+      ],
+    }),
   );
 
   server.resource(
     "issue",
     "coder://issue",
     { description: "ISSUE.md contents — the drafted issue specification" },
-    async () => {
-      const issuePath = path.join(
-        defaultWorkspace,
-        ".coder",
-        "artifacts",
-        "ISSUE.md",
-      );
-      if (!existsSync(issuePath)) {
-        return {
-          contents: [
-            {
-              uri: "coder://issue",
-              mimeType: "text/markdown",
-              text: "ISSUE.md does not exist yet.",
-            },
-          ],
-        };
-      }
-      return {
-        contents: [
-          {
-            uri: "coder://issue",
-            mimeType: "text/markdown",
-            text: readFileSync(issuePath, "utf8"),
-          },
-        ],
-      };
-    },
+    async () => ({
+      contents: [
+        {
+          uri: "coder://issue",
+          mimeType: "text/markdown",
+          text: tryReadFile(
+            path.join(defaultWorkspace, ".coder", "artifacts", "ISSUE.md"),
+            "ISSUE.md does not exist yet.",
+          ),
+        },
+      ],
+    }),
   );
 
   server.resource(
     "plan",
     "coder://plan",
     { description: "PLAN.md contents — the implementation plan" },
-    async () => {
-      const planPath = path.join(
-        defaultWorkspace,
-        ".coder",
-        "artifacts",
-        "PLAN.md",
-      );
-      if (!existsSync(planPath)) {
-        return {
-          contents: [
-            {
-              uri: "coder://plan",
-              mimeType: "text/markdown",
-              text: "PLAN.md does not exist yet.",
-            },
-          ],
-        };
-      }
-      return {
-        contents: [
-          {
-            uri: "coder://plan",
-            mimeType: "text/markdown",
-            text: readFileSync(planPath, "utf8"),
-          },
-        ],
-      };
-    },
+    async () => ({
+      contents: [
+        {
+          uri: "coder://plan",
+          mimeType: "text/markdown",
+          text: tryReadFile(
+            path.join(defaultWorkspace, ".coder", "artifacts", "PLAN.md"),
+            "PLAN.md does not exist yet.",
+          ),
+        },
+      ],
+    }),
   );
 
   server.resource(
     "critique",
     "coder://critique",
     { description: "PLANREVIEW.md contents — the plan review critique" },
-    async () => {
-      const critiquePath = path.join(
-        defaultWorkspace,
-        ".coder",
-        "artifacts",
-        "PLANREVIEW.md",
-      );
-      if (!existsSync(critiquePath)) {
-        return {
-          contents: [
-            {
-              uri: "coder://critique",
-              mimeType: "text/markdown",
-              text: "PLANREVIEW.md does not exist yet.",
-            },
-          ],
-        };
-      }
-      return {
-        contents: [
-          {
-            uri: "coder://critique",
-            mimeType: "text/markdown",
-            text: readFileSync(critiquePath, "utf8"),
-          },
-        ],
-      };
-    },
+    async () => ({
+      contents: [
+        {
+          uri: "coder://critique",
+          mimeType: "text/markdown",
+          text: tryReadFile(
+            path.join(defaultWorkspace, ".coder", "artifacts", "PLANREVIEW.md"),
+            "PLANREVIEW.md does not exist yet.",
+          ),
+        },
+      ],
+    }),
   );
 
   server.resource(
@@ -177,29 +125,15 @@ export function registerResources(server, defaultWorkspace) {
       description:
         "Current .coder/loop-state.json — develop workflow progress including issue queue and per-issue results",
     },
-    async () => {
-      const loopPath = loopStatePathFor(defaultWorkspace);
-      if (!existsSync(loopPath)) {
-        return {
-          contents: [
-            {
-              uri: "coder://loop-state",
-              mimeType: "application/json",
-              text: "{}",
-            },
-          ],
-        };
-      }
-      return {
-        contents: [
-          {
-            uri: "coder://loop-state",
-            mimeType: "application/json",
-            text: readFileSync(loopPath, "utf8"),
-          },
-        ],
-      };
-    },
+    async () => ({
+      contents: [
+        {
+          uri: "coder://loop-state",
+          mimeType: "application/json",
+          text: tryReadFile(loopStatePathFor(defaultWorkspace), "{}"),
+        },
+      ],
+    }),
   );
 
   server.resource(
@@ -214,22 +148,13 @@ export function registerResources(server, defaultWorkspace) {
       const scratchpadDir = path.join(defaultWorkspace, ".coder", "scratchpad");
       let scratchpadPath = null;
 
-      if (existsSync(statePath)) {
-        try {
-          const state = JSON.parse(readFileSync(statePath, "utf8"));
-          if (
-            typeof state?.scratchpadPath === "string" &&
-            state.scratchpadPath
-          ) {
-            const candidate = path.resolve(
-              defaultWorkspace,
-              state.scratchpadPath,
-            );
-            if (existsSync(candidate)) scratchpadPath = candidate;
-          }
-        } catch {
-          // best-effort
+      try {
+        const state = JSON.parse(readFileSync(statePath, "utf8"));
+        if (typeof state?.scratchpadPath === "string" && state.scratchpadPath) {
+          scratchpadPath = path.resolve(defaultWorkspace, state.scratchpadPath);
         }
+      } catch {
+        // best-effort
       }
 
       if (!scratchpadPath) {
@@ -248,13 +173,13 @@ export function registerResources(server, defaultWorkspace) {
         };
       }
 
+      const text = tryReadFile(
+        scratchpadPath,
+        "No scratchpad file exists yet under .coder/scratchpad.",
+      );
       return {
         contents: [
-          {
-            uri: "coder://scratchpad",
-            mimeType: "text/markdown",
-            text: readFileSync(scratchpadPath, "utf8"),
-          },
+          { uri: "coder://scratchpad", mimeType: "text/markdown", text },
         ],
       };
     },

--- a/src/mcp/tools/workflows.js
+++ b/src/mcp/tools/workflows.js
@@ -254,9 +254,12 @@ function readWorkflowEvents(
     "logs",
     `${workflowName}.jsonl`,
   );
-  if (!existsSync(logPath)) return { events: [], nextSeq: 0, totalLines: 0 };
-
-  const content = readFileSync(logPath, "utf8");
+  let content;
+  try {
+    content = readFileSync(logPath, "utf8");
+  } catch {
+    return { events: [], nextSeq: 0, totalLines: 0 };
+  }
   const allLines = content.split("\n").filter((l) => l.trim());
   const totalLines = allLines.length;
   const events = [];

--- a/src/workflows/_base.js
+++ b/src/workflows/_base.js
@@ -236,6 +236,12 @@ export class WorkflowRunner {
     while (this.ctx.cancelToken.paused && !this.ctx.cancelToken.cancelled) {
       if (Date.now() - start > MAX_PAUSE_MS) {
         this.ctx.cancelToken.cancelled = true;
+        this.ctx.log({
+          event: "workflow_pause_timeout",
+          workflow: this.name,
+          runId: this.runId,
+          pausedDurationMs: Date.now() - start,
+        });
         break;
       }
       await new Promise((r) => setTimeout(r, CHECK_INTERVAL_MS));

--- a/src/workflows/develop.workflow.js
+++ b/src/workflows/develop.workflow.js
@@ -419,7 +419,6 @@ function resolveDependencyBranch(issue, outcomeMap) {
   }
 
   const outcomes = {};
-  let _successCount = 0;
   let failCount = 0;
   let baseBranch = null;
 
@@ -431,7 +430,6 @@ function resolveDependencyBranch(issue, outcomeMap) {
     }
     outcomes[depId] = outcome.status;
     if (outcome.status === "completed" && outcome.branch) {
-      _successCount++;
       // Use the first successful dependency branch as base
       if (!baseBranch) baseBranch = outcome.branch;
     } else if (outcome.status === "failed" || outcome.status === "skipped") {


### PR DESCRIPTION
## Summary
- **#167**: `AgentPool.setRepoRoot` — extract cwd from cache key using `slice` instead of `split(":")[2]`, correctly handles colons in paths
- **#162**: TOCTOU in MCP resource handlers — replace `existsSync` + `readFileSync` pattern with `tryReadFile` helper (try-catch), also fix `readWorkflowEvents` in workflows.js. Net -71 lines.
- **#171**: Paused workflow 24h timeout — emit `workflow_pause_timeout` log event instead of silently cancelling
- **#165**: Remove dead `_successCount` variable in `resolveDependencyBranch`

Also closed as non-bugs:
- **#170**: `anthropic-version: 2023-06-01` is the current stable Messages API version
- **#166**: PID reuse risk is mitigated by 60s age-based fallback

Closes #162, closes #165, closes #167, closes #171

## Test plan
- [x] All 324 tests pass, biome clean
- [ ] CI passes