### PR TITLE
feat: add `coder version` subcommand

### DIFF
--- a/bin/coder.js
+++ b/bin/coder.js
@@ -751,10 +751,16 @@ async function runPpcommitCli() {
 
 function runVersionCli() {
   const pkgDir = path.resolve(new URL("..", import.meta.url).pathname);
-  const pkg = JSON.parse(readFileSync(path.join(pkgDir, "package.json"), "utf8"));
+  const pkg = JSON.parse(
+    readFileSync(path.join(pkgDir, "package.json"), "utf8"),
+  );
 
   const git = (args) => {
-    const r = spawnSync("git", args, { cwd: pkgDir, encoding: "utf8", timeout: 5000 });
+    const r = spawnSync("git", args, {
+      cwd: pkgDir,
+      encoding: "utf8",
+      timeout: 5000,
+    });
     return r.status === 0 ? r.stdout.trim() : null;
   };
 
@@ -788,6 +794,11 @@ const subcommand = process.argv[2];
 
 if (!subcommand || subcommand === "--help" || subcommand === "-h") {
   process.stdout.write(usage());
+  process.exit(0);
+}
+
+if (subcommand === "--version" || subcommand === "-V") {
+  runVersionCli();
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- Adds `coder version` subcommand that prints package version plus git branch, commit, and dirty state
- When installed from source (`npm install -g .`), shows e.g. `1.0.0-rc.0 (dev@9a51caa)`
- When installed from npm (no `.git` dir), shows just `1.0.0-rc.0`

## Test plan
- [ ] `coder version` from a source-linked install shows branch and commit
- [ ] `node bin/coder.js version` works in the repo
- [ ] `coder --help` lists the new subcommand