### PR TITLE
feat: fix: activeRuns stores Promise.resolve() instead of actual run promise

### DIFF
--- a/src/mcp/tools/workflows.js
+++ b/src/mcp/tools/workflows.js
@@ -705,7 +705,7 @@ export function registerWorkflowTools(server, resolveWorkspace) {
           };
 
           // Fire and forget — run in background
-          const runPromise = (async () => {
+          const runPromise = Promise.resolve().then(async () => {
             try {
               let result;
               if (workflow === "develop") {
@@ -792,7 +792,7 @@ export function registerWorkflowTools(server, resolveWorkspace) {
               activeRuns.delete(nextRunId);
               await agentPool.killAll();
             }
-          })();
+          });
 
           // Store run entry with real promise so cancel can await it
           activeRuns.set(nextRunId, {


### PR DESCRIPTION
# Metadata
Source: github
Issue ID: #192
Repo Root: /home/fcc/Programming/AITOOLS/coder

# Problem
In `src/mcp/tools/workflows.js`, when a workflow is started, `activeRuns.set()` is called with a placeholder `promise: Promise.resolve()`. The actual asynchronous `runPromise` from the workflow IIFE is assigned later via `activeRuns.get(nextRunId).promise = runPromise`. This exposes a brief period where cancellation logic or status checks might interact with the dummy `Promise.resolve()` instead of the actual pending workflow promise.

While PR #181 proposed simply moving the `activeRuns.set()` call *after* the IIFE definition, doing so naively introduces a memory leak for workflows that fail or complete synchronously (e.g., `Unknown workflow`). If the IIFE evaluates synchronously up to `activeRuns.delete(nextRunId)`, the deletion will run *before* `activeRuns.set(nextRunId, ...)` has a chance to execute, leaving a permanently stuck run in the `activeRuns` Map.

Closes #192