### PR TITLE
fix: ppcommit assertGitleaksInstalled handles EACCES/EPERM

### DIFF
--- a/src/ppcommit.js
+++ b/src/ppcommit.js
@@ -183,7 +183,7 @@ function assertGitleaksInstalled() {
     encoding: "utf8",
     timeout: 5000,
   });
-  if (res.error?.code === "ENOENT") {
+  if (["ENOENT", "EACCES", "EPERM"].includes(res.error?.code)) {
     throw new Error(
       `gitleaks binary not found in PATH.\n` +
         `  PATH searched: ${process.env.PATH}\n` +

--- a/test/ppcommit.test.js
+++ b/test/ppcommit.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -272,6 +272,46 @@ test("ppcommit: gitleaks missing from PATH produces actionable error", async () 
   // Include node + git dirs but exclude gitleaks
   const nodeBin = path.dirname(process.execPath);
   const restrictedPath = `${nodeBin}:/usr/bin:/bin`;
+  const r = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    encoding: "utf8",
+    timeout: 15000,
+    env: { ...process.env, PATH: restrictedPath, NODE_ENV: "test" },
+  });
+  const out = r.stdout || "";
+  assert.doesNotMatch(out, /NO_ERROR/, "should have thrown an error");
+  assert.match(out, /gitleaks binary not found in PATH/);
+  assert.match(out, /gitleaks\/gitleaks/);
+  assert.match(out, /blockSecrets/);
+});
+
+test("ppcommit: gitleaks not executable (EACCES) produces actionable error", {
+  skip: process.platform === "win32" || process.getuid?.() === 0,
+}, async () => {
+  const repo = makeRepo();
+  writeFileSync(path.join(repo, "a.js"), "const x = 1;\n", "utf8");
+
+  const binDir = path.join(
+    mkdtempSync(path.join(os.tmpdir(), "coder-bin-")),
+    "bin",
+  );
+  mkdirSync(binDir, { recursive: true });
+
+  const gitleaksPath = path.join(binDir, "gitleaks");
+  writeFileSync(gitleaksPath, "#!/bin/sh\nexit 0\n", "utf8");
+  chmodSync(gitleaksPath, 0o644);
+
+  const srcPath = path.resolve(import.meta.dirname, "..", "src", "ppcommit.js");
+  const script = `
+      import { runPpcommitNative } from ${JSON.stringify("file://" + srcPath)};
+      try {
+        await runPpcommitNative(${JSON.stringify(repo)}, { blockSecrets: true });
+        process.stdout.write("NO_ERROR");
+      } catch (e) {
+        process.stdout.write(e.message);
+      }
+    `;
+  const nodeBin = path.dirname(process.execPath);
+  const restrictedPath = `${binDir}:${nodeBin}:/usr/bin:/bin`;
   const r = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
     encoding: "utf8",
     timeout: 15000,


### PR DESCRIPTION
## Summary

- Expand `assertGitleaksInstalled()` error code check from only `ENOENT` to also handle `EACCES` and `EPERM`, so users get the actionable "gitleaks binary not found" message on permission-restricted systems
- Add test case covering the `EACCES` scenario (non-executable gitleaks binary in PATH)

## Files Changed

- `src/ppcommit.js` — broaden error code check in `assertGitleaksInstalled()`
- `test/ppcommit.test.js` — new test for EACCES error path

Fixes #194

## Test plan

- [ ] Existing ppcommit tests pass (`node --test test/ppcommit.test.js`)
- [ ] New EACCES test passes on Linux (auto-skipped on Windows and root)
- [ ] Biome lint passes