### PR TITLE
fix: isolate mcp-workspace tests from CODER_ALLOW_ANY_WORKSPACE env

### DIFF
--- a/test/mcp-workspace.test.js
+++ b/test/mcp-workspace.test.js
@@ -43,8 +43,10 @@ test("resolveWorkspaceForMcp rejects workspace outside root", () => {
   const root = makeDir("coder-mcp-root-");
   const outside = makeDir("coder-mcp-outside-");
   try {
-    assert.throws(() => resolveWorkspaceForMcp(outside, root), {
-      message: /Workspace must be within server root/,
+    withEnv("CODER_ALLOW_ANY_WORKSPACE", undefined, () => {
+      assert.throws(() => resolveWorkspaceForMcp(outside, root), {
+        message: /Workspace must be within server root/,
+      });
     });
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -58,8 +60,10 @@ test("resolveWorkspaceForMcp rejects symlink escape target", () => {
   const escapeLink = path.join(root, "escape");
   symlinkSync(outside, escapeLink, "dir");
   try {
-    assert.throws(() => resolveWorkspaceForMcp(escapeLink, root), {
-      message: /Workspace must be within server root/,
+    withEnv("CODER_ALLOW_ANY_WORKSPACE", undefined, () => {
+      assert.throws(() => resolveWorkspaceForMcp(escapeLink, root), {
+        message: /Workspace must be within server root/,
+      });
     });
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -74,8 +78,10 @@ test("resolveWorkspaceForMcp rejects non-existent child under symlink escape", (
   symlinkSync(outside, escapeLink, "dir");
   const target = path.join(escapeLink, "new-child");
   try {
-    assert.throws(() => resolveWorkspaceForMcp(target, root), {
-      message: /Workspace must be within server root/,
+    withEnv("CODER_ALLOW_ANY_WORKSPACE", undefined, () => {
+      assert.throws(() => resolveWorkspaceForMcp(target, root), {
+        message: /Workspace must be within server root/,
+      });
     });
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -101,8 +107,10 @@ test("resolveWorkspaceForMcp returns resolved realpath for symlink inside root",
   const link = path.join(root, "link-to-sub");
   symlinkSync(realSub, link, "dir");
   try {
-    const resolved = resolveWorkspaceForMcp(link, root);
-    assert.equal(resolved, realpathSync(realSub));
+    withEnv("CODER_ALLOW_ANY_WORKSPACE", undefined, () => {
+      const resolved = resolveWorkspaceForMcp(link, root);
+      assert.equal(resolved, realpathSync(realSub));
+    });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Wraps 4 workspace boundary tests with `withEnv("CODER_ALLOW_ANY_WORKSPACE", undefined, ...)` to clear the env var during assertion
- **Root cause**: the coder systemd service sets `CODER_ALLOW_ANY_WORKSPACE=1`, which leaks into `npm test` when the workflow runs tests — `resolveWorkspaceForMcp` short-circuits on line 6 and never throws, causing "Missing expected exception" failures
- This was the reason **all 5 issues** in the coder workflow failed at quality review with "Tests failed after review"

## Test plan
- [x] `npm test` passes (331/331)
- [x] `CODER_ALLOW_ANY_WORKSPACE=1 npm test` passes (330/331 — 1 pre-existing flaky test in logging unrelated to this change)
- [x] `npx biome check` clean

Fixes the systemic test failure that blocked all workflow runs.