### PR TITLE
feat: fix: per-workspace write chain isolation in workflow-state.js

### DIFF
--- a/src/state/workflow-state.js
+++ b/src/state/workflow-state.js
@@ -21,6 +21,8 @@ const WORKFLOW_STATE_SCHEMA_VERSION = 2;
 const _writeChains = new Map();
 /** @type {Map<string, Promise<void>>} */
 const _sqliteWriteChains = new Map();
+/** @type {null | ((filePath: string, data: unknown) => Promise<void> | void)} */
+let _beforeAtomicWriteJsonForTests = null;
 
 function getWriteChain(key) {
   return _writeChains.get(key) || Promise.resolve();
@@ -50,6 +52,15 @@ async function atomicWriteJson(filePath, data) {
       `Failed to write state ${filePath} [${op}]${code}: ${err.message}`,
     );
   }
+}
+
+async function writeJson(filePath, data) {
+  await _beforeAtomicWriteJsonForTests?.(filePath, data);
+  await atomicWriteJson(filePath, data);
+}
+
+export function __setBeforeAtomicWriteJsonForTests(fn) {
+  _beforeAtomicWriteJsonForTests = fn || null;
 }
 
 async function _persistSnapshotToSqliteInner(sqlitePath, payload) {
@@ -124,7 +135,7 @@ export async function saveWorkflowSnapshot(
   };
   let writeErr;
   const chain = getWriteChain(workspaceDir)
-    .then(() => atomicWriteJson(statePath, payload))
+    .then(() => writeJson(statePath, payload))
     .catch((e) => {
       writeErr = e;
     });
@@ -159,7 +170,7 @@ export async function saveWorkflowTerminalState(
   };
   let writeErr;
   const chain = getWriteChain(workspaceDir)
-    .then(() => atomicWriteJson(statePath, payload))
+    .then(() => writeJson(statePath, payload))
     .catch((e) => {
       writeErr = e;
     });
@@ -365,7 +376,7 @@ export async function saveLoopState(
   }
   let writeErr;
   const chain = getWriteChain(workspaceDir)
-    .then(() => atomicWriteJson(p, loopState))
+    .then(() => writeJson(p, loopState))
     .catch((e) => {
       writeErr = e;
     });
@@ -525,7 +536,7 @@ export async function saveState(workspaceDir, state) {
   const p = statePathFor(workspaceDir);
   let writeErr;
   const chain = getWriteChain(workspaceDir)
-    .then(() => atomicWriteJson(p, state))
+    .then(() => writeJson(p, state))
     .catch((e) => {
       writeErr = e;
     });

--- a/test/workflow-state.test.js
+++ b/test/workflow-state.test.js
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { createActor } from "xstate";
 import {
+  __setBeforeAtomicWriteJsonForTests,
   createWorkflowLifecycleMachine,
   loadLoopState,
   loadState,
@@ -21,6 +22,18 @@ function makeTmpDir() {
   const dir = mkdtempSync(path.join(os.tmpdir(), "coder-wf-state-"));
   mkdirSync(path.join(dir, ".coder"), { recursive: true });
   return dir;
+}
+
+function deferred() {
+  /** @type {(value?: void | PromiseLike<void>) => void} */
+  let resolve;
+  /** @type {(reason?: unknown) => void} */
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 test("statePathFor returns expected path", () => {
@@ -319,63 +332,77 @@ test("concurrent saveWorkflowSnapshot calls serialize without errors", async () 
   rmSync(ws, { recursive: true, force: true });
 });
 
-test("cross-workspace concurrent writes are isolated", async () => {
+test("cross-workspace concurrent writes are isolated", async (t) => {
   const wsA = makeTmpDir();
   const wsB = makeTmpDir();
-  const writes = [];
+  const wsAPath = statePathFor(wsA);
+  const writeBlocked = deferred();
+  const writeStarted = deferred();
+  let wsBResolved = false;
 
-  for (let i = 0; i < 5; i++) {
-    writes.push(
-      saveState(wsA, {
-        selected: { source: "github", id: `A-${i}`, title: `Issue A-${i}` },
-        selectedProject: null,
-        linearProjects: null,
-        repoPath: ".",
-        baseBranch: "main",
-        branch: null,
-        questions: null,
-        answers: null,
-        steps: {},
-        claudeSessionId: null,
-        lastError: null,
-        reviewFingerprint: null,
-        reviewedAt: null,
-        prUrl: null,
-        prBranch: null,
-        prBase: null,
-        scratchpadPath: null,
-        lastWipPushAt: null,
-      }),
-      saveState(wsB, {
-        selected: { source: "github", id: `B-${i}`, title: `Issue B-${i}` },
-        selectedProject: null,
-        linearProjects: null,
-        repoPath: ".",
-        baseBranch: "main",
-        branch: null,
-        questions: null,
-        answers: null,
-        steps: {},
-        claudeSessionId: null,
-        lastError: null,
-        reviewFingerprint: null,
-        reviewedAt: null,
-        prUrl: null,
-        prBranch: null,
-        prBase: null,
-        scratchpadPath: null,
-        lastWipPushAt: null,
-      }),
-    );
-  }
+  __setBeforeAtomicWriteJsonForTests(async (filePath) => {
+    if (filePath !== wsAPath) return;
+    writeStarted.resolve();
+    await writeBlocked.promise;
+  });
+  t.after(() => __setBeforeAtomicWriteJsonForTests(null));
 
-  await Promise.all(writes);
+  const writeA = saveState(wsA, {
+    selected: { source: "github", id: "A-0", title: "Issue A-0" },
+    selectedProject: null,
+    linearProjects: null,
+    repoPath: ".",
+    baseBranch: "main",
+    branch: null,
+    questions: null,
+    answers: null,
+    steps: {},
+    claudeSessionId: null,
+    lastError: null,
+    reviewFingerprint: null,
+    reviewedAt: null,
+    prUrl: null,
+    prBranch: null,
+    prBase: null,
+    scratchpadPath: null,
+    lastWipPushAt: null,
+  });
+  await writeStarted.promise;
+
+  const writeB = saveState(wsB, {
+    selected: { source: "github", id: "B-0", title: "Issue B-0" },
+    selectedProject: null,
+    linearProjects: null,
+    repoPath: ".",
+    baseBranch: "main",
+    branch: null,
+    questions: null,
+    answers: null,
+    steps: {},
+    claudeSessionId: null,
+    lastError: null,
+    reviewFingerprint: null,
+    reviewedAt: null,
+    prUrl: null,
+    prBranch: null,
+    prBase: null,
+    scratchpadPath: null,
+    lastWipPushAt: null,
+  }).then(() => {
+    wsBResolved = true;
+  });
+
+  await assert.doesNotReject(writeB);
+  assert.equal(wsBResolved, true);
+
+  writeBlocked.resolve();
+  await assert.doesNotReject(writeA);
 
   const [stateA, stateB] = await Promise.all([loadState(wsA), loadState(wsB)]);
   assert.ok(stateA.selected);
   assert.ok(stateB.selected);
-  assert.equal(stateA.selected.id, "A-4");
-  assert.equal(stateB.selected.id, "B-4");
+  assert.equal(stateA.selected.id, "A-0");
+  assert.equal(stateB.selected.id, "B-0");
 
   rmSync(wsA, { recursive: true, force: true });
   rmSync(wsB, { recursive: true, force: true });


### PR DESCRIPTION
# ISSUE.md

## 1. Metadata
- **Source:** github
- **Issue ID:** #191
- **Repo Root:** .

## 2. Problem
`_writeChain` and `_sqliteWriteChain` in `src/state/workflow-state.js` are currently (or were previously) global promise chains shared across all workspaces. This setup causes unnecessary delays and cross-workspace interference, as state save operations from multiple workspaces serialize through the exact same promise chain instead of executing independently.

Closes #191