### PR TITLE
chore: sync main into dev (PR #211 fixes)

### DIFF
--- a/src/agents/pool.js
+++ b/src/agents/pool.js
@@ -37,9 +37,28 @@ class RetryFallbackWrapper extends AgentAdapter {
         this._primary[method](prompt, opts),
       );
     } catch (err) {
+      // On auth error with an active session, retry primary once without
+      // session state before falling through to the fallback agent.
+      if (
+        err.name === "CommandFatalStderrError" &&
+        err.category === "auth" &&
+        opts?.resumeId
+      ) {
+        const { resumeId: _, sessionId: _s, ...cleanOpts } = opts;
+        try {
+          return await this._callWithRetry(() =>
+            this._primary[method](prompt, cleanOpts),
+          );
+        } catch {
+          // fall through to fallback
+        }
+      }
+
       if (this._fallback) {
+        // Strip session-specific opts so fallback starts fresh
+        const { resumeId: _, sessionId: _s, ...fallbackOpts } = opts || {};
         return await this._callWithRetry(() =>
-          this._fallback[method](prompt, opts),
+          this._fallback[method](prompt, fallbackOpts),
         );
       }
       throw err;

--- a/src/config.js
+++ b/src/config.js
@@ -100,7 +100,7 @@ export const WorkflowAgentRolesSchema = z.object({
 export const WorkflowWipSchema = z.object({
   push: z.boolean().default(true),
   autoCommit: z.boolean().default(true),
-  includeUntracked: z.boolean().default(false),
+  includeUntracked: z.boolean().default(true),
   remote: z.string().default("origin"),
   failOnError: z.boolean().default(false),
 });

--- a/src/github/dependencies.js
+++ b/src/github/dependencies.js
@@ -91,6 +91,43 @@ function topologicalSort(ids, deps, dependents) {
 }
 
 /**
+ * Get all transitive dependents of a failed issue via BFS.
+ * Returns the set of issue IDs that transitively depend on `failedId`.
+ *
+ * @param {Array<{ id: string, dependsOn?: string[] }>} issues
+ * @param {string} failedId
+ * @returns {Set<string>}
+ */
+export function getTransitiveDependents(issues, failedId) {
+  // Build dependents map: parent -> children that depend on it
+  const ids = new Set(issues.map((i) => i.id));
+  const dependents = new Map();
+  for (const id of ids) dependents.set(id, new Set());
+
+  for (const issue of issues) {
+    for (const dep of issue.dependsOn || issue.depends_on || []) {
+      if (!ids.has(dep)) continue;
+      dependents.get(dep).add(issue.id);
+    }
+  }
+
+  // BFS from failedId
+  const result = new Set();
+  const queue = [failedId];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    for (const child of dependents.get(current) || []) {
+      if (!result.has(child)) {
+        result.add(child);
+        queue.push(child);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
  * Get the issues in execution order, respecting dependencies.
  *
  * @param {Array<{ id: string, title: string, dependsOn?: string[] }>} issues

--- a/src/machines/develop/issue-list.machine.js
+++ b/src/machines/develop/issue-list.machine.js
@@ -255,13 +255,19 @@ export default defineMachine({
         );
       }
 
-      const filtered = issueIds
-        ? local.issues.filter((iss) =>
-            issueIds.some(
-              (id) => id.toLowerCase() === String(iss.id).toLowerCase(),
-            ),
-          )
-        : local.issues;
+      let filtered;
+      if (issueIds) {
+        const idLower = issueIds.map((id) => id.toLowerCase());
+        filtered = local.issues
+          .filter((iss) => idLower.includes(String(iss.id).toLowerCase()))
+          .sort((a, b) => {
+            const ai = idLower.indexOf(String(a.id).toLowerCase());
+            const bi = idLower.indexOf(String(b.id).toLowerCase());
+            return ai - bi;
+          });
+      } else {
+        filtered = local.issues;
+      }
 
       ctx.log({
         event: "step1_local_issues",
@@ -274,7 +280,7 @@ export default defineMachine({
         data: {
           issues: filtered,
           recommended_index: 0,
-          source: "local",
+          source: issueIds ? "forced" : "local",
         },
       };
     }
@@ -284,7 +290,8 @@ export default defineMachine({
       const fetchFn =
         issueSource === "github" ? fetchGithubIssues : fetchGitlabIssues;
       const raw = fetchFn(ctx.workspaceDir);
-      const idSet = new Set(issueIds.map((id) => id.toLowerCase()));
+      const idLower = issueIds.map((id) => id.toLowerCase());
+      const idSet = new Set(idLower);
       const matched = raw
         .filter((issue) => {
           const id = `#${issue.number ?? issue.iid}`;
@@ -302,7 +309,12 @@ export default defineMachine({
           });
           return parsed.success ? parsed.data : null;
         })
-        .filter(Boolean);
+        .filter(Boolean)
+        .sort((a, b) => {
+          const ai = idLower.indexOf(String(a.id).toLowerCase());
+          const bi = idLower.indexOf(String(b.id).toLowerCase());
+          return ai - bi;
+        });
       ctx.log({
         event: "step1_forced_ids",
         source: issueSource,

--- a/src/workflows/develop.workflow.js
+++ b/src/workflows/develop.workflow.js
@@ -3,7 +3,10 @@ import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { appendFile } from "node:fs/promises";
 import path from "node:path";
-import { buildDependencyGraph } from "../github/dependencies.js";
+import {
+  buildDependencyGraph,
+  getTransitiveDependents,
+} from "../github/dependencies.js";
 import { detectDefaultBranch } from "../helpers.js";
 import { registerMachine } from "../machines/_registry.js";
 import {
@@ -125,7 +128,11 @@ export async function runPlanLoop(
     const verdict = reviewRound.results[0]?.data?.verdict;
     ctx.log({ event: "plan_review_verdict", verdict, round, maxRounds });
 
-    const needsRevision = verdict === "REVISE" || verdict === "REJECT";
+    if (verdict === "UNKNOWN") {
+      ctx.log({ event: "plan_review_unparseable", round });
+    }
+    const needsRevision =
+      verdict === "REVISE" || verdict === "REJECT" || verdict === "UNKNOWN";
     if (!needsRevision || round === maxRounds - 1) {
       if (needsRevision && round === maxRounds - 1) {
         ctx.log({
@@ -357,7 +364,7 @@ export async function runDevelopPipeline(opts, ctx) {
  * @param {Array<{ id: string, difficulty?: number, depends_on?: string[], dependsOn?: string[] }>} issues
  * @returns {{ queue: typeof issues, rationale: { method: string, cycles: string[][], depEdges: number } }}
  */
-function buildIssueQueue(issues) {
+function buildIssueQueue(issues, { source } = {}) {
   // Normalize depends_on (support both field names)
   const normalized = issues.map((iss) => ({
     ...iss,
@@ -366,6 +373,13 @@ function buildIssueQueue(issues) {
 
   const hasDeps = normalized.some((iss) => iss.dependsOn.length > 0);
   if (!hasDeps) {
+    // Forced order: preserve caller's sequence (no difficulty re-sort)
+    if (source === "forced") {
+      return {
+        queue: normalized,
+        rationale: { method: "forced_order", cycles: [], depEdges: 0 },
+      };
+    }
     // No dependencies — sort by difficulty (ascending), stable for ties
     const sorted = [...normalized].sort(
       (a, b) => (a.difficulty || 3) - (b.difficulty || 3),
@@ -482,7 +496,20 @@ export async function runDevelopLoop(opts, ctx) {
     };
   }
 
-  const rawIssues = listResult.data.issues.slice(0, maxIssues);
+  const issueListSource = listResult.data.source || "remote";
+  let rawIssues;
+  if (issueListSource === "forced") {
+    rawIssues = listResult.data.issues;
+    if (rawIssues.length > maxIssues) {
+      ctx.log({
+        event: "forced_exceeds_max",
+        count: rawIssues.length,
+        maxIssues,
+      });
+    }
+  } else {
+    rawIssues = listResult.data.issues.slice(0, maxIssues);
+  }
   if (rawIssues.length === 0) {
     return {
       status: "completed",
@@ -494,7 +521,9 @@ export async function runDevelopLoop(opts, ctx) {
   }
 
   // Build dependency-aware queue
-  const { queue: issues, rationale } = buildIssueQueue(rawIssues);
+  const { queue: issues, rationale } = buildIssueQueue(rawIssues, {
+    source: issueListSource,
+  });
 
   ctx.log({
     event: "queue_built",
@@ -503,7 +532,7 @@ export async function runDevelopLoop(opts, ctx) {
     cycles: rationale.cycles.length,
     count: issues.length,
     order: issues.map((i) => i.id),
-    source: listResult.data.source || "remote",
+    source: issueListSource,
   });
 
   // Initialize loop state — merge terminal statuses from prior run.
@@ -801,58 +830,55 @@ export async function runDevelopLoop(opts, ctx) {
     const issueStatus = await processIssue(issues[i], i);
     if (issueStatus !== "failed") continue;
 
+    // Skip only transitive dependents of the failed issue; independent issues continue.
     const failedIssueId = issues[i]?.id;
-    ctx.log({
-      event: "loop_aborted_on_failure",
-      issueId: failedIssueId,
-      reason: "issue_failed",
-    });
-
-    for (let j = 0; j < loopState.issueQueue.length; j++) {
-      const entry = loopState.issueQueue[j];
-      if (entry.status !== "pending" && entry.status !== "deferred") continue;
-
-      entry.status = "skipped";
-      entry.error = "Skipped: prior issue failed";
-      entry.completedAt = new Date().toISOString();
-      outcomeMap.set(entry.id, { status: "skipped" });
-      skipped++;
-
-      const issueEnv = {
-        CODER_HOOK_ISSUE_ID: String(entry.id || ""),
-        CODER_HOOK_ISSUE_TITLE: String(entry.title || ""),
-      };
+    const dependentIds = getTransitiveDependents(issues, failedIssueId);
+    if (dependentIds.size > 0) {
       ctx.log({
-        event: "issue_skipped",
-        issueId: entry.id,
-        reason: "aborted_after_failure",
-        failedIssueId,
+        event: "skipping_dependents",
+        issueId: failedIssueId,
+        dependents: [...dependentIds],
       });
-      runHooks(
-        ctx,
-        loopRunId,
-        "issue_skipped",
-        "",
-        {
-          status: "skipped",
-          reason: "aborted_after_failure",
-          failedIssueId,
-        },
-        issueEnv,
-      );
 
-      results.push({
-        id: entry.id,
-        title: entry.title,
-        status: "skipped",
-        error: entry.error,
+      for (let j = 0; j < loopState.issueQueue.length; j++) {
+        const entry = loopState.issueQueue[j];
+        if (!dependentIds.has(entry.id)) continue;
+        if (entry.status !== "pending" && entry.status !== "deferred") continue;
+
+        entry.status = "skipped";
+        entry.error = `Skipped: depends on failed issue ${failedIssueId}`;
+        entry.completedAt = new Date().toISOString();
+        outcomeMap.set(entry.id, { status: "skipped" });
+        skipped++;
+
+        const issueEnv = {
+          CODER_HOOK_ISSUE_ID: String(entry.id || ""),
+          CODER_HOOK_ISSUE_TITLE: String(entry.title || ""),
+        };
+        ctx.log({
+          event: "issue_skipped",
+          issueId: entry.id,
+          reason: "depends_on_failed",
+          failedIssueId,
+        });
+        runHooks(
+          ctx,
+          loopRunId,
+          "issue_skipped",
+          "",
+          {
+            status: "skipped",
+            reason: "depends_on_failed",
+            failedIssueId,
+          },
+          issueEnv,
+        );
+      }
+
+      await saveLoopState(ctx.workspaceDir, loopState, {
+        guardRunId: loopState.runId,
       });
     }
-
-    await saveLoopState(ctx.workspaceDir, loopState, {
-      guardRunId: loopState.runId,
-    });
-    break;
   }
 
   // Retry pass for deferred issues whose dependencies are now resolved

--- a/test/agents-retry.test.js
+++ b/test/agents-retry.test.js
@@ -246,3 +246,110 @@ test("isRateLimitError detects 429, rate limit, resource_exhausted, quota", () =
   assert.equal(isRateLimitError("regular error"), false);
   assert.equal(isRateLimitError(""), false);
 });
+
+// --- Bug 1: fallback receives no resumeId; primary retried on auth error ---
+
+test("fallback agent receives no resumeId or sessionId", async () => {
+  let fallbackOpts = null;
+
+  const config = CoderConfigSchema.parse({
+    agents: {
+      retry: { retries: 1, backoffMs: 0 },
+      fallback: { planner: "codex" },
+    },
+  });
+  const pool = makePool(config);
+
+  const primaryMock = makeMockAgent([
+    { exitCode: 1, stdout: "", stderr: "primary failed" },
+  ]);
+  const fallbackMock = {
+    async execute(_prompt, opts) {
+      fallbackOpts = opts;
+      return { exitCode: 0, stdout: "ok", stderr: "" };
+    },
+    async executeStructured(prompt, opts) {
+      return this.execute(prompt, opts);
+    },
+    async executeWithRetry(prompt, opts) {
+      return this.execute(prompt, opts);
+    },
+    async kill() {},
+  };
+
+  const { agent } = pool.getAgent("planner");
+  agent._primary = primaryMock;
+  agent._fallback = fallbackMock;
+
+  await agent.execute("test prompt", {
+    resumeId: "sess-123",
+    sessionId: "sid-456",
+    timeoutMs: 5000,
+  });
+
+  assert.ok(fallbackOpts, "fallback should have been called");
+  assert.equal(fallbackOpts.resumeId, undefined, "resumeId must be stripped");
+  assert.equal(fallbackOpts.sessionId, undefined, "sessionId must be stripped");
+  assert.equal(fallbackOpts.timeoutMs, 5000, "other opts preserved");
+});
+
+test("primary retried without session on auth error before falling to fallback", async () => {
+  const calls = [];
+
+  const config = CoderConfigSchema.parse({
+    agents: {
+      retry: { retries: 1, backoffMs: 0 },
+      fallback: { planner: "codex" },
+    },
+  });
+  const pool = makePool(config);
+
+  const primaryMock = {
+    async execute(_prompt, opts) {
+      calls.push({ agent: "primary", hasResumeId: !!opts?.resumeId });
+      if (opts?.resumeId) {
+        const err = new Error("auth error");
+        err.name = "CommandFatalStderrError";
+        err.category = "auth";
+        throw err;
+      }
+      return { exitCode: 0, stdout: "ok from primary retry", stderr: "" };
+    },
+    async executeStructured(prompt, opts) {
+      return this.execute(prompt, opts);
+    },
+    async executeWithRetry(prompt, opts) {
+      return this.execute(prompt, opts);
+    },
+    async kill() {},
+  };
+  const fallbackMock = {
+    async execute(_prompt, opts) {
+      calls.push({ agent: "fallback", hasResumeId: !!opts?.resumeId });
+      return { exitCode: 0, stdout: "ok from fallback", stderr: "" };
+    },
+    async executeStructured(prompt, opts) {
+      return this.execute(prompt, opts);
+    },
+    async executeWithRetry(prompt, opts) {
+      return this.execute(prompt, opts);
+    },
+    async kill() {},
+  };
+
+  const { agent } = pool.getAgent("planner");
+  agent._primary = primaryMock;
+  agent._fallback = fallbackMock;
+
+  const result = await agent.execute("test prompt", {
+    resumeId: "sess-123",
+    sessionId: "sid-456",
+  });
+
+  // Primary was called with session (shouldRetry returns false for auth → no p-retry retries),
+  // then retried once without session and succeeded.
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0], { agent: "primary", hasResumeId: true });
+  assert.deepEqual(calls[1], { agent: "primary", hasResumeId: false });
+  assert.equal(result.stdout, "ok from primary retry");
+});

--- a/test/develop-loop-stop-processing.test.js
+++ b/test/develop-loop-stop-processing.test.js
@@ -94,9 +94,8 @@ function completedRunnerResult(runId = "run-test") {
   };
 }
 
-test("hard failure aborts queue and emits issue_skipped hooks for auto-skipped items", async () => {
+test("independent issues continue after failure (no blanket abort)", async () => {
   const ws = makeTmpWorkspace();
-  const hookLog = path.join(ws, "hook-events.log");
   const originalRun = WorkflowRunner.prototype.run;
 
   try {
@@ -144,6 +143,89 @@ test("hard failure aborts queue and emits issue_skipped hooks for auto-skipped i
       return completedRunnerResult("run-hard-fail");
     };
 
+    const ctx = makeCtx(ws);
+    const result = await runDevelopLoop(
+      { issueSource: "local", localIssuesDir: issuesDir },
+      ctx,
+    );
+
+    // B and C are independent — they should be processed, not skipped
+    assert.deepEqual(issueDraftCalls, ["A", "B", "C"]);
+    assert.equal(result.completed, 2);
+    assert.equal(result.failed, 1);
+    assert.equal(result.skipped, 0);
+
+    // No duplicate entries in results
+    const resultIds = result.results.map((r) => r.id);
+    assert.deepEqual(
+      resultIds,
+      [...new Set(resultIds)],
+      "results must not contain duplicates",
+    );
+
+    const finalState = await loadLoopState(ws);
+    const issueA = finalState.issueQueue.find((issue) => issue.id === "A");
+    const issueB = finalState.issueQueue.find((issue) => issue.id === "B");
+    const issueC = finalState.issueQueue.find((issue) => issue.id === "C");
+    assert.equal(issueA.status, "failed");
+    assert.equal(issueB.status, "completed");
+    assert.equal(issueC.status, "completed");
+  } finally {
+    WorkflowRunner.prototype.run = originalRun;
+    rmSync(ws, { recursive: true, force: true });
+  }
+});
+
+test("dependency chain: dependents skipped, independent issues continue", async () => {
+  const ws = makeTmpWorkspace();
+  const hookLog = path.join(ws, "hook-events.log");
+  const originalRun = WorkflowRunner.prototype.run;
+
+  try {
+    // A fails, B depends on A → skipped, C is independent → completes
+    const issuesDir = writeLocalManifest(ws, [
+      { id: "A", title: "Issue A", difficulty: 1 },
+      { id: "B", title: "Issue B", difficulty: 2, dependsOn: ["A"] },
+      { id: "C", title: "Issue C", difficulty: 3 },
+    ]);
+    const issueDraftCalls = [];
+    let currentIssueId = null;
+
+    WorkflowRunner.prototype.run = async function runStub(steps) {
+      const machineName = steps[0]?.machine?.name;
+      if (machineName === "develop.issue_draft") {
+        currentIssueId = steps[0]?.inputMapper?.()?.issue?.id;
+        issueDraftCalls.push(currentIssueId);
+      }
+      if (
+        machineName === "develop.planning" ||
+        machineName === "develop.plan_review"
+      ) {
+        return {
+          status: "completed",
+          results: [{ status: "ok", data: { verdict: "APPROVED" } }],
+          runId: "run-dep-skip",
+          durationMs: 0,
+        };
+      }
+      if (machineName === "develop.implementation" && currentIssueId === "A") {
+        return {
+          status: "failed",
+          error: "fatal build failure",
+          results: [
+            {
+              machine: "develop.quality_review",
+              status: "error",
+              error: "fatal build failure",
+            },
+          ],
+          runId: "run-dep-skip",
+          durationMs: 0,
+        };
+      }
+      return completedRunnerResult("run-dep-skip");
+    };
+
     const hookCmd = `printf '%s\\n' "$CODER_HOOK_ISSUE_ID" >> ${JSON.stringify(hookLog)}`;
     const ctx = makeCtx(ws, {
       config: {
@@ -161,10 +243,18 @@ test("hard failure aborts queue and emits issue_skipped hooks for auto-skipped i
       ctx,
     );
 
-    assert.deepEqual(issueDraftCalls, ["A"]);
-    assert.equal(result.completed, 0);
+    // A failed, B skipped (depends on A), C completed (independent)
     assert.equal(result.failed, 1);
-    assert.equal(result.skipped, 2);
+    assert.equal(result.skipped, 1);
+    assert.equal(result.completed, 1);
+
+    // No duplicate entries in results
+    const resultIds = result.results.map((r) => r.id);
+    assert.deepEqual(
+      resultIds,
+      [...new Set(resultIds)],
+      "results must not contain duplicates",
+    );
 
     const finalState = await loadLoopState(ws);
     const issueA = finalState.issueQueue.find((issue) => issue.id === "A");
@@ -172,15 +262,16 @@ test("hard failure aborts queue and emits issue_skipped hooks for auto-skipped i
     const issueC = finalState.issueQueue.find((issue) => issue.id === "C");
     assert.equal(issueA.status, "failed");
     assert.equal(issueB.status, "skipped");
-    assert.equal(issueC.status, "skipped");
+    assert.equal(issueC.status, "completed");
 
+    // Only B should have been skipped via hook
     const hookIds = existsSync(hookLog)
       ? readFileSync(hookLog, "utf8")
           .split("\n")
           .map((line) => line.trim())
           .filter(Boolean)
       : [];
-    assert.deepEqual(hookIds.sort(), ["B", "C"]);
+    assert.deepEqual(hookIds, ["B"]);
   } finally {
     WorkflowRunner.prototype.run = originalRun;
     rmSync(ws, { recursive: true, force: true });

--- a/test/develop-queue.test.js
+++ b/test/develop-queue.test.js
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import {
   buildDependencyGraph,
+  getTransitiveDependents,
   orderByDependencies,
 } from "../src/github/dependencies.js";
 
@@ -221,4 +222,163 @@ test("diamond dependency: D depends on B and C, both depend on A", () => {
   assert.ok(sorted.indexOf("A") < sorted.indexOf("C"));
   assert.ok(sorted.indexOf("B") < sorted.indexOf("D"));
   assert.ok(sorted.indexOf("C") < sorted.indexOf("D"));
+});
+
+// --- getTransitiveDependents ---
+
+test("getTransitiveDependents returns direct dependents", () => {
+  const issues = [
+    { id: "A", dependsOn: [] },
+    { id: "B", dependsOn: ["A"] },
+    { id: "C", dependsOn: [] },
+  ];
+  const deps = getTransitiveDependents(issues, "A");
+  assert.ok(deps.has("B"));
+  assert.ok(!deps.has("C"));
+  assert.ok(!deps.has("A"));
+});
+
+test("getTransitiveDependents returns transitive chain", () => {
+  const issues = [
+    { id: "A", dependsOn: [] },
+    { id: "B", dependsOn: ["A"] },
+    { id: "C", dependsOn: ["B"] },
+    { id: "D", dependsOn: [] },
+  ];
+  const deps = getTransitiveDependents(issues, "A");
+  assert.ok(deps.has("B"));
+  assert.ok(deps.has("C"));
+  assert.ok(!deps.has("D"));
+});
+
+test("getTransitiveDependents handles diamond shape", () => {
+  const issues = [
+    { id: "A", dependsOn: [] },
+    { id: "B", dependsOn: ["A"] },
+    { id: "C", dependsOn: ["A"] },
+    { id: "D", dependsOn: ["B", "C"] },
+    { id: "E", dependsOn: [] },
+  ];
+  const deps = getTransitiveDependents(issues, "A");
+  assert.deepEqual([...deps].sort(), ["B", "C", "D"]);
+  assert.ok(!deps.has("E"));
+});
+
+test("getTransitiveDependents returns empty set for leaf node", () => {
+  const issues = [
+    { id: "A", dependsOn: [] },
+    { id: "B", dependsOn: ["A"] },
+  ];
+  const deps = getTransitiveDependents(issues, "B");
+  assert.equal(deps.size, 0);
+});
+
+// --- Forced order preservation ---
+
+test("forced local issues preserve order through develop loop queue", async () => {
+  const { execSync } = await import("node:child_process");
+  const { WorkflowRunner } = await import("../src/workflows/_base.js");
+  const { runDevelopLoop } = await import(
+    "../src/workflows/develop.workflow.js"
+  );
+
+  const ws = mkdtempSync(path.join(os.tmpdir(), "forced-order-"));
+  mkdirSync(path.join(ws, ".coder", "artifacts"), { recursive: true });
+  mkdirSync(path.join(ws, ".coder", "logs"), { recursive: true });
+  execSync("git init", { cwd: ws, stdio: "ignore" });
+  execSync("git config user.email test@example.com", {
+    cwd: ws,
+    stdio: "ignore",
+  });
+  execSync("git config user.name 'Test User'", { cwd: ws, stdio: "ignore" });
+  execSync("git commit --allow-empty -m init", { cwd: ws, stdio: "ignore" });
+
+  // Issues in intentional order: highest difficulty first
+  const issuesDir = path.join(ws, ".coder", "local-issues");
+  const issuesSubdir = path.join(issuesDir, "issues");
+  mkdirSync(issuesSubdir, { recursive: true });
+  writeFileSync(
+    path.join(issuesDir, "manifest.json"),
+    JSON.stringify({
+      issues: [
+        { id: "Z", file: "issues/Z.md", title: "Hard", difficulty: 5 },
+        { id: "A", file: "issues/A.md", title: "Easy", difficulty: 1 },
+        { id: "M", file: "issues/M.md", title: "Med", difficulty: 3 },
+      ],
+    }),
+  );
+  for (const id of ["Z", "A", "M"]) {
+    writeFileSync(path.join(issuesSubdir, `${id}.md`), `# ${id}\n\nDetails.`);
+  }
+
+  const originalRun = WorkflowRunner.prototype.run;
+  const draftOrder = [];
+  try {
+    WorkflowRunner.prototype.run = async (steps) => {
+      const name = steps[0]?.machine?.name;
+      if (name === "develop.issue_draft") {
+        draftOrder.push(steps[0]?.inputMapper?.()?.issue?.id);
+      }
+      if (name === "develop.planning" || name === "develop.plan_review") {
+        return {
+          status: "completed",
+          results: [{ status: "ok", data: { verdict: "APPROVED" } }],
+          runId: "r",
+          durationMs: 0,
+        };
+      }
+      return {
+        status: "completed",
+        results: [
+          {
+            machine: "develop.pr_creation",
+            status: "ok",
+            data: { branch: "feat/test", prUrl: "https://example.test/pr" },
+          },
+        ],
+        runId: "r",
+        durationMs: 0,
+      };
+    };
+
+    const ctx = {
+      workspaceDir: ws,
+      repoPath: ".",
+      artifactsDir: path.join(ws, ".coder", "artifacts"),
+      scratchpadDir: path.join(ws, ".coder", "scratchpad"),
+      cancelToken: { cancelled: false, paused: false },
+      log: () => {},
+      config: {
+        workflow: {
+          maxMachineRetries: 0,
+          retryBackoffMs: 0,
+          hooks: [],
+          issueSource: "local",
+          localIssuesDir: "",
+        },
+      },
+      agentPool: null,
+      secrets: {},
+    };
+
+    await runDevelopLoop(
+      {
+        issueSource: "local",
+        localIssuesDir: issuesDir,
+        issueIds: ["Z", "A", "M"],
+      },
+      ctx,
+    );
+
+    // Without forced_order, difficulty sort would reorder to A(1), M(3), Z(5)
+    // With forced_order, original sequence Z, A, M must be preserved
+    assert.deepEqual(
+      draftOrder,
+      ["Z", "A", "M"],
+      "forced order must be preserved",
+    );
+  } finally {
+    WorkflowRunner.prototype.run = originalRun;
+    rmSync(ws, { recursive: true, force: true });
+  }
 });

--- a/test/plan-loop.test.js
+++ b/test/plan-loop.test.js
@@ -249,12 +249,13 @@ test("runPlanLoop: stops at maxRounds even with repeated REVISE", async () => {
   }
 });
 
-test("runPlanLoop: UNKNOWN verdict stops after 1 round", async () => {
+test("runPlanLoop: UNKNOWN verdict triggers revision then APPROVED stops", async () => {
   const tmp = makeTmp();
   try {
     const ctx = makeCtx(tmp);
     const runner = makeRunner(ctx);
     let planCount = 0;
+    let reviewCount = 0;
 
     const mockPlan = {
       name: "develop.planning",
@@ -266,9 +267,13 @@ test("runPlanLoop: UNKNOWN verdict stops after 1 round", async () => {
     const mockReview = {
       name: "develop.plan_review",
       async run() {
+        reviewCount++;
         return {
           status: "ok",
-          data: { critiqueMd: "?", verdict: "UNKNOWN" },
+          data: {
+            critiqueMd: reviewCount === 1 ? "unparseable" : "ok",
+            verdict: reviewCount === 1 ? "UNKNOWN" : "APPROVED",
+          },
           durationMs: 0,
         };
       },
@@ -280,7 +285,8 @@ test("runPlanLoop: UNKNOWN verdict stops after 1 round", async () => {
     });
 
     assert.equal(result.status, "completed");
-    assert.equal(planCount, 1);
+    assert.equal(planCount, 2);
+    assert.equal(reviewCount, 2);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Syncs PR #211 (`fix/develop-loop-bugs`) from main back into dev
- Closes #209, #210

Fixes: session ID leak to fallback agent, queue ordering, UNKNOWN verdict handling, dependency-aware abort scope, includeUntracked default.