### PR TITLE
fix: extend quality-review session retry to cover create-path collisions

### DIFF
--- a/src/machines/develop/quality-review.machine.js
+++ b/src/machines/develop/quality-review.machine.js
@@ -354,15 +354,18 @@ export default defineMachine({
               timeoutMs: ctx.config.workflow.timeouts.reviewRound,
             });
           } catch (err) {
-            if (
+            const isAuthError =
               reviewerSupportsSession &&
               err.name === "CommandFatalStderrError" &&
-              err.category === "auth" &&
-              reviewSessionOpts.resumeId
-            ) {
+              err.category === "auth";
+            const canRetryWithFreshSession =
+              isAuthError &&
+              (reviewSessionOpts.resumeId || reviewSessionOpts.sessionId);
+            if (canRetryWithFreshSession) {
               ctx.log({
                 event: "session_auth_failed",
                 sessionId: state.reviewerSessionId,
+                wasCreating: !!reviewSessionOpts.sessionId,
               });
               state.reviewerSessionId = randomUUID();
               await saveState(ctx.workspaceDir, state);


### PR DESCRIPTION
## Summary
- Followup to PR #227 — the quality-review machine's inline session retry was only half-fixed (event renamed but retry condition not extended)
- Applies the same `canRetryWithFreshSession` pattern used in `_session.js` and `planning.machine.js`
- Without this, a session ID collision on review round 1 (create path) would throw instead of retrying with a fresh UUID

## Test plan
- [x] `npx biome check src/ bin/ test/` — clean
- [x] `node --test` — 484 pass, 0 fail