### PR TITLE
fix: kill on stdout patterns for Claude session ID collision

### DIFF
--- a/src/agents/cli-agent.js
+++ b/src/agents/cli-agent.js
@@ -311,12 +311,19 @@ export class CliAgent extends AgentAdapter {
             ? CODEX_FAILURE_PATTERNS
             : [];
     const killOnStderrPatterns = opts.killOnStderrPatterns ?? defaultPatterns;
+    // Claude emits "Session ID X is already in use" to stdout, not stderr — kill on both
+    const killOnStdoutPatterns =
+      opts.killOnStdoutPatterns ??
+      (isClaude && (opts.resumeId || opts.sessionId)
+        ? CLAUDE_RESUME_FAILURE_PATTERNS
+        : []);
 
     const result = await sandbox.commands.run(cmd, {
       timeoutMs: opts.timeoutMs ?? 1000 * 60 * 10,
       hangTimeoutMs,
       hangResetOnStderr,
       killOnStderrPatterns,
+      killOnStdoutPatterns,
     });
 
     if (isCodex && opts.execWithJsonCapture && result.stdout) {
@@ -372,7 +379,11 @@ export class CliAgent extends AgentAdapter {
           const err = ctx.error;
           if (err.name === "AbortError") return false;
           if (err.name === "CommandTimeoutError") return false;
-          if (err.name === "CommandFatalStderrError" && err.category === "auth")
+          if (
+            (err.name === "CommandFatalStderrError" ||
+              err.name === "CommandFatalStdoutError") &&
+            err.category === "auth"
+          )
             return false;
           if (err.name === "McpStartupError") return false;
           return true;

--- a/src/agents/pool.js
+++ b/src/agents/pool.js
@@ -40,7 +40,8 @@ class RetryFallbackWrapper extends AgentAdapter {
       // On auth error with an active session, retry primary once without
       // session state before falling through to the fallback agent.
       if (
-        err.name === "CommandFatalStderrError" &&
+        (err.name === "CommandFatalStderrError" ||
+          err.name === "CommandFatalStdoutError") &&
         err.category === "auth" &&
         opts?.resumeId
       ) {
@@ -93,7 +94,8 @@ class RetryFallbackWrapper extends AgentAdapter {
           const name = ctx.error.name;
           if (name === "CommandTimeoutError") return false;
           if (
-            name === "CommandFatalStderrError" &&
+            (name === "CommandFatalStderrError" ||
+              name === "CommandFatalStdoutError") &&
             ctx.error.category === "auth"
           )
             return false;

--- a/src/host-sandbox.js
+++ b/src/host-sandbox.js
@@ -50,6 +50,15 @@ export class CommandFatalStderrError extends Error {
   }
 }
 
+export class CommandFatalStdoutError extends Error {
+  constructor(pattern, category) {
+    super(`Command aborted after fatal stdout match [${category}]: ${pattern}`);
+    this.name = "CommandFatalStdoutError";
+    this.pattern = pattern;
+    this.category = category;
+  }
+}
+
 export class McpStartupError extends Error {
   constructor(agentName, failedServers) {
     super(
@@ -159,6 +168,14 @@ class HostSandboxInstance extends EventEmitter {
     const hangResetOnStderr = options.hangResetOnStderr ?? true;
     const killOnStderrPatterns = Array.isArray(options.killOnStderrPatterns)
       ? options.killOnStderrPatterns.filter(
+          (p) =>
+            typeof p?.pattern === "string" &&
+            p.pattern.trim() !== "" &&
+            typeof p?.category === "string",
+        )
+      : [];
+    const killOnStdoutPatterns = Array.isArray(options.killOnStdoutPatterns)
+      ? options.killOnStdoutPatterns.filter(
           (p) =>
             typeof p?.pattern === "string" &&
             p.pattern.trim() !== "" &&
@@ -301,6 +318,20 @@ class HostSandboxInstance extends EventEmitter {
         resetHangTimer();
         options.onStdout?.(chunk);
         this.emit("stdout", chunk);
+
+        if (killOnStdoutPatterns.length > 0) {
+          const lower = chunk.toLowerCase();
+          const hit = killOnStdoutPatterns.find((p) =>
+            lower.includes(p.pattern.toLowerCase()),
+          );
+          if (hit) {
+            terminateChild();
+            const err = new CommandFatalStdoutError(hit.pattern, hit.category);
+            err.stdout = stdout;
+            err.stderr = stderr;
+            settle(err);
+          }
+        }
       });
       child.stderr.on("data", (buf) => {
         const chunk = buf.toString();

--- a/src/machines/develop/_session.js
+++ b/src/machines/develop/_session.js
@@ -73,7 +73,8 @@ export async function withSessionResume({
   } catch (err) {
     const isAuthError =
       isSupported &&
-      err.name === "CommandFatalStderrError" &&
+      (err.name === "CommandFatalStderrError" ||
+        err.name === "CommandFatalStdoutError") &&
       err.category === "auth";
     const canRetryWithFreshSession =
       isAuthError && (sessionOpts.resumeId || sessionOpts.sessionId);

--- a/src/machines/develop/implementation.machine.js
+++ b/src/machines/develop/implementation.machine.js
@@ -221,7 +221,8 @@ FORBIDDEN patterns:
       res = await programmerAgent.execute(implPrompt, execOpts);
     } catch (err) {
       if (
-        err.name === "CommandFatalStderrError" &&
+        (err.name === "CommandFatalStderrError" ||
+          err.name === "CommandFatalStdoutError") &&
         err.category === "auth" &&
         state[sessionKey]
       ) {

--- a/src/machines/develop/planning.machine.js
+++ b/src/machines/develop/planning.machine.js
@@ -268,7 +268,9 @@ ${branchSections}`;
           });
         } catch (err) {
           const isAuthError =
-            err.name === "CommandFatalStderrError" && err.category === "auth";
+            (err.name === "CommandFatalStderrError" ||
+              err.name === "CommandFatalStdoutError") &&
+            err.category === "auth";
           const canRetryWithFreshSession =
             isAuthError && (sessionOpts.resumeId || sessionOpts.sessionId);
           if (canRetryWithFreshSession) {

--- a/src/machines/develop/quality-review.machine.js
+++ b/src/machines/develop/quality-review.machine.js
@@ -356,7 +356,8 @@ export default defineMachine({
           } catch (err) {
             const isAuthError =
               reviewerSupportsSession &&
-              err.name === "CommandFatalStderrError" &&
+              (err.name === "CommandFatalStderrError" ||
+                err.name === "CommandFatalStdoutError") &&
               err.category === "auth";
             const canRetryWithFreshSession =
               isAuthError &&

--- a/test/host-sandbox.test.js
+++ b/test/host-sandbox.test.js
@@ -50,6 +50,30 @@ test("host sandbox aborts on Codex session-not-found pattern (auth category)", a
   );
 });
 
+test("host sandbox aborts command on configured stdout auth-failure pattern (session already in use)", async () => {
+  const provider = new HostSandboxProvider();
+  const sandbox = await provider.create();
+
+  await assert.rejects(
+    async () =>
+      sandbox.commands.run(
+        `echo "Error: Session ID 57ce9ef7-f502-451c-a258-535c8b62ccf5 is already in use."; sleep 2; echo "should-not-print"`,
+        {
+          timeoutMs: 5000,
+          killOnStdoutPatterns: [
+            { pattern: "is already in use", category: "auth" },
+          ],
+        },
+      ),
+    (err) => {
+      assert.equal(err.name, "CommandFatalStdoutError");
+      assert.equal(err.category, "auth");
+      assert.equal(err.pattern, "is already in use");
+      return true;
+    },
+  );
+});
+
 test("host sandbox aborts with transient category on matching stderr pattern", async () => {
   const provider = new HostSandboxProvider();
   const sandbox = await provider.create();

--- a/test/repro-gh-89.test.js
+++ b/test/repro-gh-89.test.js
@@ -11,6 +11,13 @@ function makeCommandFatalStderrError(message, category = "auth") {
   return err;
 }
 
+function makeCommandFatalStdoutError(message, category = "auth") {
+  const err = new Error(message);
+  err.name = "CommandFatalStdoutError";
+  err.category = category;
+  return err;
+}
+
 function makeConfig() {
   return CoderConfigSchema.parse({});
 }
@@ -118,6 +125,12 @@ test("All expected Claude resume failure patterns are present", async () => {
       `should include pattern: "${pattern}"`,
     );
   }
+  // Claude emits "Session ID X is already in use" to stdout — must also kill on stdout
+  assert.equal(
+    capturedOpts.killOnStdoutPatterns.length,
+    expected.length,
+    "should wire same patterns to killOnStdoutPatterns for stdout errors",
+  );
 });
 
 test("CliAgent does NOT add resume patterns for claude without resumeId or sessionId", async () => {
@@ -141,6 +154,7 @@ test("CliAgent does NOT add resume patterns for claude without resumeId or sessi
 
   await agent.execute("test prompt", {});
   assert.deepEqual(capturedOpts.killOnStderrPatterns, []);
+  assert.deepEqual(capturedOpts.killOnStdoutPatterns, []);
 });
 
 test("CliAgent does NOT add resume patterns for gemini with resumeId", async () => {
@@ -225,6 +239,48 @@ test("CommandFatalStderrError with category auth and resumeId triggers session r
   assert.equal(calls.length, 2);
   assert.equal(calls[0].opts.resumeId, sessionId);
   assert.equal(calls[1].opts.resumeId, undefined);
+});
+
+test("CommandFatalStdoutError with category auth and resumeId triggers session retry (stdout path)", async () => {
+  const calls = [];
+  const mockAgent = {
+    async execute(prompt, opts) {
+      calls.push({ prompt, opts });
+      if (calls.length === 1) {
+        throw makeCommandFatalStdoutError(
+          "Command aborted after fatal stdout match [auth]: Session ID X is already in use",
+        );
+      }
+      return { exitCode: 0, stdout: "ok", stderr: "" };
+    },
+  };
+
+  const sessionId = "stale-session-uuid";
+  let currentSessionId = sessionId;
+  let res;
+
+  try {
+    res = await mockAgent.execute("do stuff", {
+      resumeId: currentSessionId,
+      timeoutMs: 60_000,
+    });
+  } catch (err) {
+    if (
+      (err.name === "CommandFatalStderrError" ||
+        err.name === "CommandFatalStdoutError") &&
+      err.category === "auth" &&
+      currentSessionId
+    ) {
+      currentSessionId = null;
+      res = await mockAgent.execute("do stuff", { timeoutMs: 60_000 });
+    } else {
+      throw err;
+    }
+  }
+
+  assert.equal(res.exitCode, 0);
+  assert.equal(currentSessionId, null);
+  assert.equal(calls.length, 2);
 });
 
 test("CommandFatalStderrError with category auth without resumeId is not caught as session failure", async () => {


### PR DESCRIPTION
Claude CLI emits 'Session ID X is already in use' to stdout, not stderr. Add killOnStdoutPatterns so the process is killed immediately instead of waiting for the 300s hang timeout. Wire CLAUDE_RESUME_FAILURE_PATTERNS to both stderr and stdout for Claude session resume. Update session retry logic to handle CommandFatalStdoutError alongside CommandFatalStderrError.

Made-with: Cursor