### PR TITLE
fix: research workflow parity with develop infrastructure

### DIFF
--- a/src/machines/research/_shared.js
+++ b/src/machines/research/_shared.js
@@ -15,6 +15,33 @@ import { CancelledError } from "../_base.js";
 import { withSessionResume } from "../_session.js";
 
 /**
+ * Load session state from the run directory.
+ * @param {string} runDir
+ * @returns {object}
+ */
+export function loadSessionState(runDir) {
+  const p = path.join(runDir, "session-state.json");
+  if (!existsSync(p)) return {};
+  try {
+    return JSON.parse(readFileSync(p, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Save session state to the run directory.
+ * @param {string} runDir
+ * @param {object} state
+ */
+export function saveSessionState(runDir, state) {
+  writeFileSync(
+    path.join(runDir, "session-state.json"),
+    `${JSON.stringify(state, null, 2)}\n`,
+  );
+}
+
+/**
  * Chunk a large pointer text into manageable pieces for analysis.
  * @param {string} text
  * @param {{ maxChars?: number, maxChunks?: number }} [opts]

--- a/src/machines/research/deep-research.machine.js
+++ b/src/machines/research/deep-research.machine.js
@@ -1,9 +1,12 @@
+import path from "node:path";
 import { z } from "zod";
-import { defineMachine } from "../_base.js";
+import { checkCancel, defineMachine } from "../_base.js";
 import {
   loadPipeline,
+  loadSessionState,
   resolveArtifact,
   runStructuredStep,
+  saveSessionState,
   skipPipelineStep,
 } from "./_shared.js";
 
@@ -34,11 +37,22 @@ export default defineMachine({
       "analysis-brief",
     );
 
-    const stepOpts = { stepsDir, scratchpadPath, pipeline, pipelinePath, ctx };
+    const runDir = path.dirname(stepsDir);
+    const sessionState = loadSessionState(runDir);
+    const stepOpts = {
+      stepsDir,
+      scratchpadPath,
+      pipeline,
+      pipelinePath,
+      ctx,
+      sessionState,
+      sessionKey: "deepResearchSessionId",
+    };
 
     let webReferenceMap = { topics: [], missing_research: [] };
 
     if (webResearch) {
+      checkCancel(ctx);
       ctx.log({ event: "research_web_references" });
       const referencePrompt = `Find external implementation references for these problem spaces.
 
@@ -77,6 +91,7 @@ Return ONLY valid JSON in this schema:
         ...stepOpts,
       });
       webReferenceMap = referencesRes.payload || webReferenceMap;
+      saveSessionState(runDir, sessionState);
     } else {
       skipPipelineStep(
         pipeline,

--- a/src/machines/research/issue-critique.machine.js
+++ b/src/machines/research/issue-critique.machine.js
@@ -1,15 +1,10 @@
-import { writeFileSync } from "node:fs";
-import path from "node:path";
 import { z } from "zod";
-import { defineMachine } from "../_base.js";
+import { checkCancel, defineMachine } from "../_base.js";
 import {
   appendScratchpad,
-  beginPipelineStep,
-  endPipelineStep,
   loadPipeline,
-  parseAgentPayload,
-  requireExitZero,
   resolveArtifact,
+  runStructuredStep,
 } from "./_shared.js";
 
 export default defineMachine({
@@ -35,10 +30,6 @@ export default defineMachine({
   }),
 
   async execute(input, ctx) {
-    const { agentName, agent } = ctx.agentPool.getAgent("planReviewer", {
-      scope: "workspace",
-    });
-
     const pipeline = loadPipeline(input.pipelinePath) || {
       version: 1,
       runId: "issue-critique",
@@ -46,29 +37,15 @@ export default defineMachine({
       history: [],
       steps: {},
     };
-    const _analysisBrief = resolveArtifact(
-      input.analysisBrief,
-      input.stepsDir,
-      "analysis-brief",
-    );
-    const _webReferenceMap = resolveArtifact(
-      input.webReferenceMap,
-      input.stepsDir,
-      "web-references",
-    );
+    resolveArtifact(input.analysisBrief, input.stepsDir, "analysis-brief");
+    resolveArtifact(input.webReferenceMap, input.stepsDir, "web-references");
     const validationResults = resolveArtifact(
       input.validationResults,
       input.stepsDir,
       "validation-results",
     );
 
-    beginPipelineStep(
-      pipeline,
-      input.pipelinePath,
-      input.scratchpadPath,
-      "issue_critique",
-      { agent: agentName, issueCount: input.issues.length },
-    );
+    checkCancel(ctx);
 
     const issuesSummary = input.issues
       .map(
@@ -137,16 +114,17 @@ Return JSON:
   "feedback": ["actionable feedback items for next iteration"]
 }`;
 
-    const res = await agent.execute(prompt, {
+    const { payload, agentName } = await runStructuredStep({
+      stepName: "issue_critique",
+      role: "planReviewer",
+      prompt,
       timeoutMs: ctx.config.workflow.timeouts.researchStep,
+      stepsDir: input.stepsDir,
+      scratchpadPath: input.scratchpadPath,
+      pipeline,
+      pipelinePath: input.pipelinePath,
+      ctx,
     });
-    requireExitZero(agentName, "issue_critique", res);
-
-    const payload = parseAgentPayload(agentName, res.stdout);
-
-    // Save critique artifact
-    const critiquePath = path.join(input.stepsDir, "issue-critique.json");
-    writeFileSync(critiquePath, `${JSON.stringify(payload, null, 2)}\n`);
 
     appendScratchpad(input.scratchpadPath, "Issue Critique", [
       `- agent: ${agentName}`,
@@ -155,15 +133,6 @@ Return JSON:
       `- issues_reviewed: ${(payload?.issueReviews || []).length}`,
       `- gaps_found: ${(payload?.backlogIssues?.gaps || []).length}`,
     ]);
-
-    endPipelineStep(
-      pipeline,
-      input.pipelinePath,
-      input.scratchpadPath,
-      "issue_critique",
-      "completed",
-      { agent: agentName, verdict: payload?.verdict },
-    );
 
     return {
       status: "ok",

--- a/src/machines/research/issue-synthesis.machine.js
+++ b/src/machines/research/issue-synthesis.machine.js
@@ -1,12 +1,15 @@
 import { writeFileSync } from "node:fs";
+import path from "node:path";
 import { z } from "zod";
 import { checkCancel, defineMachine } from "../_base.js";
 import {
   appendScratchpad,
   loadPipeline,
+  loadSessionState,
   loadStepArtifact,
   resolveArtifact,
   runStructuredStep,
+  saveSessionState,
 } from "./_shared.js";
 
 export default defineMachine({
@@ -59,6 +62,8 @@ export default defineMachine({
       "validation-results",
     );
 
+    const runDir = path.dirname(stepsDir);
+    const sessionState = loadSessionState(runDir);
     const stepOpts = { stepsDir, scratchpadPath, pipeline, pipelinePath, ctx };
 
     let priorFeedback = [];
@@ -163,7 +168,10 @@ Return ONLY valid JSON in this schema:
         prompt: draftPrompt,
         timeoutMs: ctx.config.workflow.timeouts.researchStep,
         ...stepOpts,
+        sessionState,
+        sessionKey: "synthesisDraftSessionId",
       });
+      saveSessionState(runDir, sessionState);
       const draftPayload = draftRes.payload;
       if (
         !draftPayload ||
@@ -226,7 +234,10 @@ Return ONLY valid JSON in this schema:
         prompt: reviewPrompt,
         timeoutMs: ctx.config.workflow.timeouts.researchStep,
         ...stepOpts,
+        sessionState,
+        sessionKey: "synthesisCritiqueSessionId",
       });
+      saveSessionState(runDir, sessionState);
       finalReview = reviewRes.payload;
 
       const mustFix = Array.isArray(finalReview?.must_fix)

--- a/src/machines/research/poc-validation.machine.js
+++ b/src/machines/research/poc-validation.machine.js
@@ -1,9 +1,12 @@
+import path from "node:path";
 import { z } from "zod";
-import { defineMachine } from "../_base.js";
+import { checkCancel, defineMachine } from "../_base.js";
 import {
   loadPipeline,
+  loadSessionState,
   resolveArtifact,
   runStructuredStep,
+  saveSessionState,
   skipPipelineStep,
 } from "./_shared.js";
 
@@ -47,6 +50,8 @@ export default defineMachine({
       "web-references",
     );
 
+    const runDir = path.dirname(stepsDir);
+    const sessionState = loadSessionState(runDir);
     const stepOpts = { stepsDir, scratchpadPath, pipeline, pipelinePath, ctx };
 
     let validationPlan = { tracks: [] };
@@ -77,6 +82,7 @@ export default defineMachine({
     }
 
     // Plan validation tracks
+    checkCancel(ctx);
     ctx.log({ event: "research_plan_validation" });
     const validationPlanPrompt = `Create a validation plan for these pointers and references.
 
@@ -111,10 +117,14 @@ Return ONLY valid JSON in this schema:
       prompt: validationPlanPrompt,
       timeoutMs: ctx.config.workflow.timeouts.researchStep,
       ...stepOpts,
+      sessionState,
+      sessionKey: "pocPlanSessionId",
     });
     validationPlan = validationPlanRes.payload || validationPlan;
+    saveSessionState(runDir, sessionState);
 
     // Execute validation tracks
+    checkCancel(ctx);
     const tracks = Array.isArray(validationPlan?.tracks)
       ? validationPlan.tracks
       : [];
@@ -154,8 +164,11 @@ Return ONLY valid JSON in this schema:
         prompt: validationExecPrompt,
         timeoutMs: ctx.config.workflow.timeouts.pocValidation,
         ...stepOpts,
+        sessionState,
+        sessionKey: "pocExecSessionId",
       });
       validationResults = validationExecRes.payload || validationResults;
+      saveSessionState(runDir, sessionState);
     } else {
       skipPipelineStep(
         pipeline,

--- a/src/machines/research/tech-selection.machine.js
+++ b/src/machines/research/tech-selection.machine.js
@@ -1,13 +1,10 @@
 import { z } from "zod";
-import { defineMachine } from "../_base.js";
+import { checkCancel, defineMachine } from "../_base.js";
 import {
   appendScratchpad,
-  beginPipelineStep,
-  endPipelineStep,
   loadPipeline,
-  parseAgentPayload,
-  requireExitZero,
   resolveArtifact,
+  runStructuredStep,
 } from "./_shared.js";
 
 export default defineMachine({
@@ -42,10 +39,6 @@ export default defineMachine({
   }),
 
   async execute(input, ctx) {
-    const { agentName, agent } = ctx.agentPool.getAgent("planner", {
-      scope: "workspace",
-    });
-
     const pipeline = loadPipeline(input.pipelinePath) || {
       version: 1,
       runId: "tech-selection",
@@ -64,13 +57,7 @@ export default defineMachine({
       "web-references",
     );
 
-    beginPipelineStep(
-      pipeline,
-      input.pipelinePath,
-      input.scratchpadPath,
-      "tech_evaluation",
-      { agent: agentName },
-    );
+    checkCancel(ctx);
 
     const refSummary = Object.values(webRefs)
       .slice(0, 10)
@@ -137,27 +124,23 @@ Return JSON:
   }
 }`;
 
-    const res = await agent.execute(prompt, {
+    const { payload, agentName } = await runStructuredStep({
+      stepName: "tech_evaluation",
+      role: "planner",
+      prompt,
       timeoutMs: ctx.config.workflow.timeouts.researchStep,
+      stepsDir: input.stepsDir,
+      scratchpadPath: input.scratchpadPath,
+      pipeline,
+      pipelinePath: input.pipelinePath,
+      ctx,
     });
-    requireExitZero(agentName, "tech_selection", res);
-
-    const payload = parseAgentPayload(agentName, res.stdout);
 
     appendScratchpad(input.scratchpadPath, "Tech Selection", [
       `- agent: ${agentName}`,
       `- categories: ${(payload?.categories || []).length}`,
       `- stack: ${payload?.stack?.summary || "unknown"}`,
     ]);
-
-    endPipelineStep(
-      pipeline,
-      input.pipelinePath,
-      input.scratchpadPath,
-      "tech_evaluation",
-      "completed",
-      { agent: agentName },
-    );
 
     return {
       status: "ok",

--- a/src/workflows/research.workflow.js
+++ b/src/workflows/research.workflow.js
@@ -6,6 +6,7 @@ import issueSynthesisMachine from "../machines/research/issue-synthesis.machine.
 import pocValidationMachine from "../machines/research/poc-validation.machine.js";
 import specPublishMachine from "../machines/research/spec-publish.machine.js";
 import techSelectionMachine from "../machines/research/tech-selection.machine.js";
+import { runPreflight } from "../preflight.js";
 import { WorkflowRunner } from "./_base.js";
 
 export {
@@ -53,6 +54,20 @@ export function registerResearchMachines() {
  * @param {import("../machines/_base.js").WorkflowContext} ctx
  */
 export async function runResearchPipeline(opts, ctx) {
+  // Pre-flight checks — fail fast before processing
+  const preflight = ctx.config?.workflow?.preflight;
+  if (preflight?.checks?.length > 0) {
+    try {
+      await runPreflight(preflight.checks, ctx.workspaceDir);
+    } catch (err) {
+      return {
+        status: "failed",
+        error: `Pre-flight check failed: ${err.message}`,
+        results: [],
+      };
+    }
+  }
+
   const runner = new WorkflowRunner({
     name: "research",
     workflowContext: ctx,
@@ -78,6 +93,8 @@ export async function runResearchPipeline(opts, ctx) {
       },
       {
         machine: deepResearchMachine,
+        maxRetries: ctx.config?.workflow?.maxMachineRetries ?? 0,
+        backoffMs: ctx.config?.workflow?.retryBackoffMs ?? 5000,
         inputMapper: (prev) => ({
           stepsDir: prev.data.stepsDir,
           scratchpadPath: prev.data.scratchpadPath,
@@ -88,6 +105,8 @@ export async function runResearchPipeline(opts, ctx) {
       },
       {
         machine: pocValidationMachine,
+        maxRetries: ctx.config?.workflow?.maxMachineRetries ?? 0,
+        backoffMs: ctx.config?.workflow?.retryBackoffMs ?? 5000,
         inputMapper: (prev, state) => {
           const gatherData = state.results[0]?.data || {};
           return {

--- a/test/research-cancel.test.js
+++ b/test/research-cancel.test.js
@@ -1,5 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
@@ -243,5 +249,312 @@ describe("context-gather cancel", () => {
     );
 
     assert.equal(result.status, "cancelled");
+  });
+});
+
+describe("deep-research cancel", () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "deep-research-cancel-"));
+    mkdirSync(path.join(tmp, ".coder"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("deep-research respects cancel before web search", async () => {
+    const { default: deepResearchMachine } = await import(
+      "../src/machines/research/deep-research.machine.js"
+    );
+
+    const stepsDir = path.join(tmp, "steps");
+    const scratchpadPath = path.join(tmp, "SCRATCHPAD.md");
+    const pipelinePath = path.join(tmp, "pipeline.json");
+    mkdirSync(stepsDir, { recursive: true });
+    writeFileSync(scratchpadPath, "# Test\n", "utf8");
+    writeFileSync(
+      pipelinePath,
+      JSON.stringify({
+        version: 1,
+        current: "init",
+        history: [],
+        steps: {},
+      }) + "\n",
+    );
+    writeFileSync(
+      path.join(stepsDir, "analysis-brief.json"),
+      JSON.stringify({ problem_spaces: [] }),
+    );
+
+    const ctx = {
+      workspaceDir: tmp,
+      cancelToken: { cancelled: true, paused: false },
+      log: () => {},
+      config: { workflow: { timeouts: { webSearch: 60000 } } },
+      agentPool: {
+        getAgent: () => ({
+          agentName: "test",
+          agent: { execute: async () => ({ exitCode: 0, stdout: "{}" }) },
+        }),
+      },
+      secrets: {},
+      artifactsDir: path.join(tmp, ".coder", "artifacts"),
+      scratchpadDir: path.join(tmp, ".coder", "scratchpad"),
+    };
+
+    const result = await deepResearchMachine.run(
+      { stepsDir, scratchpadPath, pipelinePath, webResearch: true },
+      ctx,
+    );
+
+    assert.equal(result.status, "cancelled");
+  });
+});
+
+describe("poc-validation cancel", () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "poc-cancel-"));
+    mkdirSync(path.join(tmp, ".coder"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("poc-validation respects cancel between plan and execute", async () => {
+    const { default: pocValidationMachine } = await import(
+      "../src/machines/research/poc-validation.machine.js"
+    );
+
+    const stepsDir = path.join(tmp, "steps");
+    const scratchpadPath = path.join(tmp, "SCRATCHPAD.md");
+    const pipelinePath = path.join(tmp, "pipeline.json");
+    mkdirSync(stepsDir, { recursive: true });
+    writeFileSync(scratchpadPath, "# Test\n", "utf8");
+    writeFileSync(
+      pipelinePath,
+      JSON.stringify({
+        version: 1,
+        current: "init",
+        history: [],
+        steps: {},
+      }) + "\n",
+    );
+    writeFileSync(
+      path.join(stepsDir, "analysis-brief.json"),
+      JSON.stringify({ problem_spaces: [] }),
+    );
+
+    let callCount = 0;
+    const cancelToken = { cancelled: false, paused: false };
+
+    const ctx = {
+      workspaceDir: tmp,
+      cancelToken,
+      log: () => {},
+      config: {
+        workflow: {
+          timeouts: { researchStep: 60000, pocValidation: 60000 },
+        },
+      },
+      agentPool: {
+        getAgent: () => ({
+          agentName: "test",
+          agent: {
+            execute: async () => {
+              callCount++;
+              // After plan step completes, cancel before execute
+              cancelToken.cancelled = true;
+              return {
+                exitCode: 0,
+                stdout: JSON.stringify({
+                  tracks: [{ id: "V1", topic: "test" }],
+                  notes: "",
+                }),
+              };
+            },
+          },
+        }),
+      },
+      secrets: {},
+      artifactsDir: path.join(tmp, ".coder", "artifacts"),
+      scratchpadDir: path.join(tmp, ".coder", "scratchpad"),
+    };
+
+    const result = await pocValidationMachine.run(
+      { stepsDir, scratchpadPath, pipelinePath, validateIdeas: true },
+      ctx,
+    );
+
+    assert.equal(result.status, "cancelled");
+    // Only 1 call: plan succeeded, then cancel fired before execute
+    assert.equal(callCount, 1);
+  });
+});
+
+describe("issue-critique cancel", () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "critique-cancel-"));
+    mkdirSync(path.join(tmp, ".coder"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("issue-critique respects cancel", async () => {
+    const { default: issueCritiqueMachine } = await import(
+      "../src/machines/research/issue-critique.machine.js"
+    );
+
+    const stepsDir = path.join(tmp, "steps");
+    const scratchpadPath = path.join(tmp, "SCRATCHPAD.md");
+    const pipelinePath = path.join(tmp, "pipeline.json");
+    mkdirSync(stepsDir, { recursive: true });
+    writeFileSync(scratchpadPath, "# Test\n", "utf8");
+    writeFileSync(
+      pipelinePath,
+      JSON.stringify({
+        version: 1,
+        current: "init",
+        history: [],
+        steps: {},
+      }) + "\n",
+    );
+
+    const ctx = {
+      workspaceDir: tmp,
+      cancelToken: { cancelled: true, paused: false },
+      log: () => {},
+      config: { workflow: { timeouts: { researchStep: 60000 } } },
+      agentPool: {
+        getAgent: () => ({
+          agentName: "test",
+          agent: { execute: async () => ({ exitCode: 0, stdout: "{}" }) },
+        }),
+      },
+      secrets: {},
+      artifactsDir: path.join(tmp, ".coder", "artifacts"),
+      scratchpadDir: path.join(tmp, ".coder", "scratchpad"),
+    };
+
+    const result = await issueCritiqueMachine.run(
+      {
+        issues: [{ id: "IDEA-01", title: "Test" }],
+        repoRoot: tmp,
+        stepsDir,
+        scratchpadPath,
+        pipelinePath,
+      },
+      ctx,
+    );
+
+    assert.equal(result.status, "cancelled");
+  });
+});
+
+describe("tech-selection cancel", () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "tech-cancel-"));
+    mkdirSync(path.join(tmp, ".coder"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("tech-selection respects cancel", async () => {
+    const { default: techSelectionMachine } = await import(
+      "../src/machines/research/tech-selection.machine.js"
+    );
+
+    const stepsDir = path.join(tmp, "steps");
+    const scratchpadPath = path.join(tmp, "SCRATCHPAD.md");
+    const pipelinePath = path.join(tmp, "pipeline.json");
+    mkdirSync(stepsDir, { recursive: true });
+    writeFileSync(scratchpadPath, "# Test\n", "utf8");
+    writeFileSync(
+      pipelinePath,
+      JSON.stringify({
+        version: 1,
+        current: "init",
+        history: [],
+        steps: {},
+      }) + "\n",
+    );
+
+    const ctx = {
+      workspaceDir: tmp,
+      cancelToken: { cancelled: true, paused: false },
+      log: () => {},
+      config: { workflow: { timeouts: { researchStep: 60000 } } },
+      agentPool: {
+        getAgent: () => ({
+          agentName: "test",
+          agent: { execute: async () => ({ exitCode: 0, stdout: "{}" }) },
+        }),
+      },
+      secrets: {},
+      artifactsDir: path.join(tmp, ".coder", "artifacts"),
+      scratchpadDir: path.join(tmp, ".coder", "scratchpad"),
+    };
+
+    const result = await techSelectionMachine.run(
+      {
+        requirements: "Test requirements",
+        stepsDir,
+        scratchpadPath,
+        pipelinePath,
+      },
+      ctx,
+    );
+
+    assert.equal(result.status, "cancelled");
+  });
+});
+
+describe("session state helpers", () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "session-state-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("round-trips session state to disk", async () => {
+    const { loadSessionState, saveSessionState } = await import(
+      "../src/machines/research/_shared.js"
+    );
+
+    // Initially empty
+    const initial = loadSessionState(tmp);
+    assert.deepEqual(initial, {});
+
+    // Save and reload
+    const state = {
+      synthesisDraftSessionId: "abc-123",
+      synthesisDraftSessionId_agent: "claude",
+    };
+    saveSessionState(tmp, state);
+
+    const loaded = loadSessionState(tmp);
+    assert.deepEqual(loaded, state);
+
+    // Verify file on disk
+    const raw = JSON.parse(
+      readFileSync(path.join(tmp, "session-state.json"), "utf8"),
+    );
+    assert.equal(raw.synthesisDraftSessionId, "abc-123");
   });
 });


### PR DESCRIPTION
## Summary
- Wire shared workflow infrastructure into research machines: session persistence, per-step retry, preflight checks, and expanded cancellation
- Migrate `issue-critique` and `tech-selection` from manual `agent.execute()`/`parseAgentPayload()` to `runStructuredStep()`, removing ~60 lines of boilerplate
- Add `checkCancel()` to 4 machines (deep-research, poc-validation at 2 points, issue-critique, tech-selection)
- Thread session state through deep-research, poc-validation, and issue-synthesis for cross-turn context
- Add retry config (`maxRetries`/`backoffMs`) to deep-research and poc-validation pipeline steps
- Add preflight checks at top of `runResearchPipeline()`

## Test plan
- [x] All 507 tests pass (`node --test`)
- [x] 5 new cancel/session tests in `test/research-cancel.test.js`
- [x] Biome linter clean on all modified files