### PR TITLE
feat: Implement `spec_build.ingest` machine

### DIFF
--- a/test/spec-ingest.machine.test.js
+++ b/test/spec-ingest.machine.test.js
@@ -127,7 +127,7 @@ test("spec_ingest build mode reads research manifest", async () => {
     assert.ok(result.data.pipelinePath);
     assert.ok(result.data.repoRoot);
 
-    // Verify pipeline.json tracking (Finding 2)
+    // Verify pipeline.json tracking
     assert.ok(existsSync(result.data.pipelinePath), "pipeline.json must exist");
     const pipeline = JSON.parse(readFileSync(result.data.pipelinePath, "utf8"));
     assert.equal(pipeline.steps.spec_ingest.status, "completed");
@@ -208,7 +208,7 @@ test("spec_ingest ingest mode parses spec directory with domains, decisions, and
     assert.equal(result.data.parsedGaps.length, 1);
     assert.equal(result.data.parsedGaps[0].domain, "AUTH");
 
-    // Verify pipeline.json tracking (Finding 2)
+    // Verify pipeline.json tracking
     assert.ok(existsSync(result.data.pipelinePath), "pipeline.json must exist");
     const pipeline = JSON.parse(readFileSync(result.data.pipelinePath, "utf8"));
     assert.equal(pipeline.steps.spec_ingest.status, "completed");


### PR DESCRIPTION
# ISSUE: SPEC-02

## 1. Metadata
- **Source**: local
- **Issue ID**: SPEC-02
- **Repo Root**: /home/fcc/Programming/AITOOLS/coder
- **Difficulty**: 3

## 2. Problem
The `spec-build` workflow requires an entry point machine (`spec_ingest`) to collect input data before the architectural decomposition or rendering phases can begin. Currently, the workflow is defined but lacks the concrete `research.spec_ingest` machine implementation to determine whether the pipeline should run in "ingest" mode (reading an existing `spec/` directory) or "build" mode (synthesizing a new spec from a previous research run). This missing implementation prevents the workflow from processing data for downstream steps.