### PR TITLE
feat: Enhancement: missing gitleaks binary should produce an actionable error message

### DIFF
--- a/test/ppcommit.test.js
+++ b/test/ppcommit.test.js
@@ -304,6 +304,26 @@ function gitleaksSpawnSkipReason() {
 
 const gitleaksSpawnSkip = gitleaksSpawnSkipReason();
 
+/** Probe: can we execute a shell script from tmpdir? noexec mounts block this. */
+function tmpNoexecSkipReason() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "coder-noexec-probe-"));
+  try {
+    const script = path.join(dir, "probe");
+    writeFileSync(script, "#!/bin/sh\nexit 0\n", "utf8");
+    chmodSync(script, FILE_MODE_EXECUTABLE);
+    const r = spawnSync(script, [], {
+      encoding: "utf8",
+      timeout: PROBE_TIMEOUT_MS,
+    });
+    if (r.error) return `tmpdir noexec (${r.error.code})`;
+    return false;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const tmpNoexecSkip = tmpNoexecSkipReason();
+
 test("ppcommit: gitleaks missing from PATH produces actionable error", {
   skip: gitleaksSpawnSkip,
 }, async () => {
@@ -422,7 +442,7 @@ test("ppcommit: gitleaks not executable (EACCES) produces actionable error", {
 });
 
 test("ppcommit: gitleaks version check failure produces distinct error", {
-  skip: gitleaksSpawnSkip,
+  skip: gitleaksSpawnSkip || tmpNoexecSkip,
 }, async () => {
   const repo = makeRepo();
   writeFileSync(path.join(repo, "a.js"), "const x = 1;\n", "utf8");


### PR DESCRIPTION
# Issue: Enhancement: missing gitleaks binary should produce an actionable error message

## 1. Metadata
- **Source**: local
- **Issue ID**: GH-84
- **Repo Root**: /home/fcc/Programming/AITOOLS/coder
- **Difficulty**: 3

## 2. Problem
In `src/ppcommit.js` (around lines 175–193), `assertGitleaksInstalled()` is called to ensure the `gitleaks` binary is available for secret scanning. When the binary is missing or not executable, the tool correctly hard-fails, but the current error message does not clearly identify the missing binary, how to install it, or how to intentionally bypass the check using the configuration. It must be updated to produce a highly actionable, user-friendly error message.