### PR TITLE
feat: add update mode to spec-build pipeline

### DIFF
--- a/src/machines/research/spec-architect.machine.js
+++ b/src/machines/research/spec-architect.machine.js
@@ -10,7 +10,7 @@ import {
 export default defineMachine({
   name: "research.spec_architect",
   description:
-    "Architectural decomposition (build mode) or gap categorization (ingest mode). " +
+    "Architectural decomposition (build mode), gap categorization (ingest mode), or update analysis (update mode). " +
     "Produces domains, decisions, phases, and issue specs for the spec_render step.",
   inputSchema: z.object({
     runDir: z.string().min(1),
@@ -18,12 +18,16 @@ export default defineMachine({
     scratchpadPath: z.string().min(1),
     pipelinePath: z.string().min(1),
     repoRoot: z.string().min(1),
-    mode: z.enum(["build", "ingest"]),
+    mode: z.enum(["build", "ingest", "update"]),
     researchManifest: z.any().default({}),
     parsedDomains: z.array(z.any()).default([]),
     parsedDecisions: z.array(z.any()).default([]),
     parsedGaps: z.array(z.any()).default([]),
     parsedPhases: z.array(z.any()).default([]),
+    updateDocContent: z.string().default(""),
+    specFiles: z
+      .array(z.object({ name: z.string(), content: z.string() }))
+      .default([]),
   }),
 
   async execute(input, ctx) {
@@ -107,6 +111,92 @@ Return ONLY valid JSON:
       return {
         status: "ok",
         data: { mode: "build", domains, decisions, phases, issueSpecs },
+      };
+    }
+
+    if (mode === "update") {
+      const specFilesText = input.specFiles
+        .map((f) => `### ${f.name}\n\n${f.content}`)
+        .join("\n\n---\n\n");
+
+      const prompt = `You are a spec update analysis agent. You have an existing specification and an update document describing a major new feature or change. Your job is to analyze what needs to change and produce structured implementation issues.
+
+Repo root: ${repoRoot}
+
+## Update Document
+
+${input.updateDocContent}
+
+## Existing Specification Files
+
+${specFilesText}
+
+## Tasks
+
+1. **Analyze the update document** — understand what new feature, behavior, or architectural change it describes.
+2. **Compare against the existing spec** — identify which spec sections are affected, what is new, and what conflicts with existing design.
+3. **Explore the codebase** at ${repoRoot} to understand the current implementation state.
+4. **Produce three categories of issues:**
+   a. **Code implementation issues** — new files, modified functions, new types/interfaces, changed behavior. Tag these with "code".
+   b. **Test issues** — new unit tests, integration tests, modified existing tests. Tag these with "test".
+   c. **Spec update issues** — which spec documents need new sections, modified sections, or entirely new documents. In the "changes" field, reference specific spec file names and section headings. Tag these with "spec-update".
+5. **Order issues by dependency** — spec updates can often be done in parallel with code, but tests depend on code.
+
+For each issue, be specific:
+- Reference exact file paths from the codebase when known
+- Reference exact spec file names (e.g., "05-HASHING.md") and section headings for spec updates
+- Include concrete acceptance criteria that can be verified
+
+Return ONLY valid JSON:
+{
+  "phases": [{"id": "phase-N", "title": "string", "issueSpecs": [{"title": "matching issue title"}]}],
+  "issueSpecs": [
+    {
+      "title": "string",
+      "objective": "string",
+      "problem": "string",
+      "changes": ["string — specific file paths or spec sections"],
+      "acceptance_criteria": ["string"],
+      "priority": "P0|P1|P2|P3",
+      "domain": "string",
+      "depends_on": ["title of dependency issue"],
+      "tags": ["code|test|spec-update"],
+      "estimated_effort": "string",
+      "testing_strategy": {
+        "existing_tests": ["string — paths to existing test files affected"],
+        "new_tests": ["string — new test files or test cases to create"],
+        "test_patterns": "string"
+      }
+    }
+  ]
+}`;
+
+      const res = await runStructuredStep({
+        stepName: "spec_architect",
+        artifactName: "spec-architect",
+        role: "issueSelector",
+        prompt,
+        ...stepOpts,
+      });
+
+      requirePayloadFields(
+        res.payload,
+        { phases: "array", issueSpecs: "array" },
+        "spec_architect (update)",
+      );
+      const { phases, issueSpecs } = res.payload;
+
+      appendScratchpad(scratchpadPath, "Spec Architect (update)", [
+        `- phases: ${phases.length}`,
+        `- issueSpecs: ${issueSpecs.length}`,
+        `- code issues: ${issueSpecs.filter((s) => s.tags?.includes("code")).length}`,
+        `- test issues: ${issueSpecs.filter((s) => s.tags?.includes("test")).length}`,
+        `- spec-update issues: ${issueSpecs.filter((s) => s.tags?.includes("spec-update")).length}`,
+      ]);
+
+      return {
+        status: "ok",
+        data: { mode: "update", phases, issueSpecs },
       };
     }
 

--- a/src/machines/research/spec-ingest.machine.js
+++ b/src/machines/research/spec-ingest.machine.js
@@ -14,12 +14,13 @@ import {
 export default defineMachine({
   name: "research.spec_ingest",
   description:
-    "Spec-build pipeline entry point: determines mode (build vs ingest) and collects input data. " +
-    "Provide existingSpecDir for ingest mode or researchRunId for build mode.",
+    "Spec-build pipeline entry point: determines mode (build, ingest, or update) and collects input data. " +
+    "Provide existingSpecDir for ingest mode, researchRunId for build mode, or updateDoc + existingSpecDir for update mode.",
   inputSchema: z.object({
     repoPath: z.string().default("."),
     existingSpecDir: z.string().default(""),
     researchRunId: z.string().default(""),
+    updateDoc: z.string().default(""),
   }),
 
   async execute(input, ctx) {
@@ -38,6 +39,80 @@ export default defineMachine({
       "spec_ingest",
       {},
     );
+
+    // UPDATE mode: updateDoc + existingSpecDir together
+    if (input.updateDoc && input.existingSpecDir) {
+      const specDir = path.resolve(ctx.workspaceDir, input.existingSpecDir);
+      if (!existsSync(specDir)) {
+        throw new Error(`existingSpecDir does not exist: ${specDir}`);
+      }
+      const updateDocPath = path.resolve(ctx.workspaceDir, input.updateDoc);
+      if (!existsSync(updateDocPath)) {
+        throw new Error(`updateDoc does not exist: ${updateDocPath}`);
+      }
+
+      const updateDocContent = readFileSync(updateDocPath, "utf8");
+
+      // Read all spec markdown files as raw text (no rigid parsing)
+      const specFiles = readdirSync(specDir)
+        .filter((f) => f.endsWith(".md"))
+        .sort()
+        .map((f) => ({
+          name: f,
+          content: readFileSync(path.join(specDir, f), "utf8"),
+        }));
+
+      // Also read markdown from subdirectories (decisions/, phases/) if present
+      for (const subdir of ["decisions", "phases"]) {
+        const subdirPath = path.join(specDir, subdir);
+        if (existsSync(subdirPath)) {
+          for (const f of readdirSync(subdirPath)
+            .filter((f) => f.endsWith(".md"))
+            .sort()) {
+            specFiles.push({
+              name: `${subdir}/${f}`,
+              content: readFileSync(path.join(subdirPath, f), "utf8"),
+            });
+          }
+        }
+      }
+
+      endPipelineStep(
+        pipeline,
+        pipelinePath,
+        scratchpadPath,
+        "spec_ingest",
+        "completed",
+        {
+          mode: "update",
+          specFiles: specFiles.length,
+          updateDocChars: updateDocContent.length,
+        },
+      );
+      appendScratchpad(scratchpadPath, "Spec Ingest (update mode)", [
+        `- specDir: ${specDir}`,
+        `- updateDoc: ${updateDocPath}`,
+        `- specFiles: ${specFiles.length}`,
+        `- updateDocChars: ${updateDocContent.length}`,
+      ]);
+
+      return {
+        status: "ok",
+        data: {
+          runId,
+          runDir,
+          stepsDir,
+          issuesDir,
+          scratchpadPath,
+          pipelinePath,
+          repoRoot,
+          repoPath: input.repoPath || ".",
+          mode: "update",
+          updateDocContent,
+          specFiles,
+        },
+      };
+    }
 
     if (input.existingSpecDir) {
       const specDir = path.resolve(ctx.workspaceDir, input.existingSpecDir);
@@ -243,7 +318,7 @@ export default defineMachine({
     }
 
     throw new Error(
-      "spec_ingest requires either existingSpecDir or researchRunId",
+      "spec_ingest requires either existingSpecDir (with optional updateDoc) or researchRunId",
     );
   },
 });

--- a/src/machines/research/spec-render.machine.js
+++ b/src/machines/research/spec-render.machine.js
@@ -168,8 +168,8 @@ function renderArchitecture(domains) {
 export default defineMachine({
   name: "research.spec_render",
   description:
-    "Renders spec documents (build mode) or skips to issue generation (ingest mode). " +
-    "Both modes write issue markdown files and a bridge manifest for the develop workflow.",
+    "Renders spec documents (build mode) or skips to issue generation (ingest/update mode). " +
+    "All modes write issue markdown files and a bridge manifest for the develop workflow.",
   inputSchema: z.object({
     runDir: z.string().min(1),
     stepsDir: z.string().min(1),
@@ -178,7 +178,7 @@ export default defineMachine({
     pipelinePath: z.string().min(1),
     repoRoot: z.string().min(1),
     repoPath: z.string().default("."),
-    mode: z.enum(["build", "ingest"]),
+    mode: z.enum(["build", "ingest", "update"]),
     domains: z.array(z.any()).default([]),
     decisions: z.array(z.any()).default([]),
     phases: z.array(z.any()).default([]),

--- a/src/mcp/tools/workflows.js
+++ b/src/mcp/tools/workflows.js
@@ -592,6 +592,12 @@ export function registerWorkflowTools(server, resolveWorkspace) {
           .describe(
             "Spec-build start-only: research run ID whose output to synthesize",
           ),
+        updateDoc: z
+          .string()
+          .default("")
+          .describe(
+            "Spec-build start-only: path to update document (use with existingSpecDir for update mode)",
+          ),
         // Events pagination
         afterSeq: z
           .number()
@@ -948,6 +954,7 @@ export function registerWorkflowTools(server, resolveWorkspace) {
                     repoPath: params.repoPath,
                     existingSpecDir: params.existingSpecDir,
                     researchRunId: params.researchRunId,
+                    updateDoc: params.updateDoc,
                   },
                   workflowCtx,
                 );

--- a/src/workflows/spec-build.workflow.js
+++ b/src/workflows/spec-build.workflow.js
@@ -30,6 +30,7 @@ export async function runSpecBuildPipeline(opts, ctx) {
         repoPath: opts.repoPath || ".",
         existingSpecDir: opts.existingSpecDir || "",
         researchRunId: opts.researchRunId || "",
+        updateDoc: opts.updateDoc || "",
       }),
     },
     {
@@ -46,6 +47,8 @@ export async function runSpecBuildPipeline(opts, ctx) {
         parsedDecisions: prev.data.parsedDecisions || [],
         parsedGaps: prev.data.parsedGaps || [],
         parsedPhases: prev.data.parsedPhases || [],
+        updateDocContent: prev.data.updateDocContent || "",
+        specFiles: prev.data.specFiles || [],
       }),
     },
     {

--- a/test/spec-build-workflow.test.js
+++ b/test/spec-build-workflow.test.js
@@ -131,6 +131,84 @@ const mockArchitectIngest = defineMachine({
   },
 });
 
+const mockIngestUpdate = defineMachine({
+  name: "research.spec_ingest",
+  description: "Mock ingest (update)",
+  inputSchema: z.object({ repoPath: z.string().default(".") }),
+  async execute() {
+    return {
+      status: "ok",
+      data: {
+        runId: "test-run",
+        runDir: "/tmp/run",
+        stepsDir: "/tmp/run/steps",
+        issuesDir: "/tmp/run/issues",
+        scratchpadPath: "/tmp/run/SCRATCHPAD.md",
+        pipelinePath: "/tmp/run/pipeline.json",
+        repoRoot: "/tmp/repo",
+        repoPath: ".",
+        mode: "update",
+        updateDocContent:
+          "# Feature X\n\nAdd ownership transfer to the cluster.",
+        specFiles: [
+          { name: "01-OVERVIEW.md", content: "# Overview\n\nExisting spec." },
+          {
+            name: "05-HASHING.md",
+            content: "# Hashing\n\nConsistent hashing.",
+          },
+        ],
+      },
+    };
+  },
+});
+
+const mockArchitectUpdate = defineMachine({
+  name: "research.spec_architect",
+  description: "Mock architect (update)",
+  inputSchema: z.object({ mode: z.string(), runDir: z.string() }),
+  async execute() {
+    return {
+      status: "ok",
+      data: {
+        mode: "update",
+        phases: [
+          {
+            id: "phase-1",
+            title: "Core implementation",
+            issueSpecs: [{ title: "Implement transfer protocol" }],
+          },
+        ],
+        issueSpecs: [
+          {
+            title: "Implement transfer protocol",
+            objective: "Add follow-the-workload ownership transfer",
+            priority: "P0",
+            domain: "ownership",
+            tags: ["code"],
+            changes: ["src/transfer.go"],
+          },
+          {
+            title: "Add transfer tests",
+            objective: "Integration tests for ownership handoff",
+            priority: "P1",
+            domain: "ownership",
+            tags: ["test"],
+            depends_on: ["Implement transfer protocol"],
+          },
+          {
+            title: "Update spec: 05-HASHING.md ownership section",
+            objective: "Add ownership transfer to hashing spec",
+            priority: "P1",
+            domain: "spec",
+            tags: ["spec-update"],
+            changes: ["05-HASHING.md: add ## Ownership Transfer section"],
+          },
+        ],
+      },
+    };
+  },
+});
+
 const mockRender = defineMachine({
   name: "research.spec_render",
   description: "Mock render",
@@ -223,6 +301,38 @@ test("spec-build pipeline cascades data in ingest mode", async () => {
   assert.equal(result.results[0].data.parsedGaps.length, 1);
   assert.equal(result.results[2].data.wroteSpecDocs, false);
   assert.equal(result.results[2].data.issueCount, 1);
+});
+
+test("spec-build pipeline cascades data in update mode", async () => {
+  const runner = new WorkflowRunner({
+    name: "spec-build",
+    workflowContext: makeCtx(),
+  });
+  const result = await runner.run([
+    { machine: mockIngestUpdate, inputMapper: () => ({ repoPath: "." }) },
+    {
+      machine: mockArchitectUpdate,
+      inputMapper: (prev) => ({
+        mode: prev.data.mode,
+        runDir: prev.data.runDir,
+      }),
+    },
+    {
+      machine: mockRender,
+      inputMapper: (prev, state) => ({
+        mode: state.results[0]?.data?.mode,
+        issueSpecs: prev.data.issueSpecs || [],
+      }),
+    },
+  ]);
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.results[0].data.mode, "update");
+  assert.equal(result.results[0].data.specFiles.length, 2);
+  assert.ok(result.results[0].data.updateDocContent.length > 0);
+  assert.equal(result.results[1].data.issueSpecs.length, 3);
+  assert.equal(result.results[2].data.wroteSpecDocs, false);
+  assert.equal(result.results[2].data.issueCount, 3);
 });
 
 test("spec-build pipeline fails on non-optional step error", async () => {
@@ -602,5 +712,132 @@ test("spec_render build mode: phase entries with _issueId bypass matching", asyn
     assert.equal(specManifest.phases[1].issueIds[0], "SPEC-01");
   } finally {
     dirs.cleanup();
+  }
+});
+
+test("spec_render update mode: writes bridge manifest without spec dir", async () => {
+  const dirs = makeTempDirs();
+  try {
+    const result = await specRenderMachine.run(
+      {
+        runDir: dirs.runDir,
+        stepsDir: dirs.stepsDir,
+        issuesDir: dirs.issuesDir,
+        scratchpadPath: dirs.scratchpadPath,
+        pipelinePath: dirs.pipelinePath,
+        repoRoot: dirs.workspace,
+        repoPath: ".",
+        mode: "update",
+        domains: [],
+        decisions: [],
+        phases: [
+          {
+            id: "phase-1",
+            title: "Core",
+            issueSpecs: [{ title: "Implement transfer" }],
+          },
+        ],
+        issueSpecs: [
+          {
+            title: "Implement transfer",
+            objective: "Add ownership transfer",
+            priority: "P0",
+            tags: ["code"],
+          },
+          {
+            title: "Update spec overview",
+            objective: "Add transfer section to overview",
+            priority: "P1",
+            tags: ["spec-update"],
+          },
+        ],
+        parsedDomains: [],
+        parsedDecisions: [],
+      },
+      {
+        workspaceDir: dirs.workspace,
+        log: () => {},
+      },
+    );
+
+    assert.equal(result.status, "ok");
+    assert.equal(result.data.specDir, null);
+    assert.equal(result.data.issueCount, 2);
+
+    // No spec dir created
+    assert.ok(!existsSync(path.join(dirs.runDir, "spec")));
+
+    // Bridge manifest exists
+    const bridgeDir = path.join(dirs.workspace, ".coder", "local-issues");
+    const bridgeManifest = JSON.parse(
+      readFileSync(path.join(bridgeDir, "manifest.json"), "utf8"),
+    );
+    assert.equal(bridgeManifest.issues.length, 2);
+    assert.ok(bridgeManifest.issues[0].filePath);
+    assert.ok(
+      existsSync(
+        path.resolve(dirs.workspace, bridgeManifest.issues[0].filePath),
+      ),
+    );
+  } finally {
+    dirs.cleanup();
+  }
+});
+
+test("spec_ingest update mode: reads update doc and spec files as raw text", async () => {
+  const base = path.join(
+    tmpdir(),
+    `spec-ingest-update-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  const workspace = path.join(base, "workspace");
+  const specDir = path.join(workspace, "spec");
+  const scratchpadDir = path.join(workspace, ".coder", "scratchpad");
+  mkdirSync(specDir, { recursive: true });
+  mkdirSync(scratchpadDir, { recursive: true });
+
+  writeFileSync(
+    path.join(specDir, "01-OVERVIEW.md"),
+    "# Overview\n\nExisting spec.",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(specDir, "05-HASHING.md"),
+    "# Hashing\n\nConsistent hashing.",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(workspace, "SPEC_UPDATE.md"),
+    "# Update\n\nAdd ownership transfer.",
+    "utf8",
+  );
+
+  try {
+    const specIngestMachine = (
+      await import("../src/machines/research/spec-ingest.machine.js")
+    ).default;
+    const result = await specIngestMachine.run(
+      {
+        repoPath: ".",
+        existingSpecDir: "spec",
+        updateDoc: "SPEC_UPDATE.md",
+      },
+      {
+        workspaceDir: workspace,
+        scratchpadDir,
+        log: () => {},
+      },
+    );
+
+    assert.equal(result.status, "ok");
+    assert.equal(result.data.mode, "update");
+    assert.equal(result.data.specFiles.length, 2);
+    assert.equal(result.data.specFiles[0].name, "01-OVERVIEW.md");
+    assert.equal(result.data.specFiles[1].name, "05-HASHING.md");
+    assert.ok(result.data.updateDocContent.includes("ownership transfer"));
+    // Should NOT have ingest-mode parsed fields
+    assert.equal(result.data.parsedDomains, undefined);
+    assert.equal(result.data.parsedGaps, undefined);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

- Adds an **update** mode to the spec-build pipeline, triggered when both `updateDoc` and `existingSpecDir` are provided
- `spec_ingest` reads the update document and all spec files as raw text (no rigid parsing required — works with freeform spec directories)
- `spec_architect` gets a new update-oriented prompt that produces issues tagged `code`, `test`, and `spec-update` based on delta analysis between the update doc and existing spec
- `spec_render` treats update mode like ingest (issues + bridge manifest only, no spec doc generation)
- Wired through `coder_workflow` MCP tool via new `updateDoc` parameter

## Test plan

- [x] New mock pipeline cascade test for update mode (3-stage data flow)
- [x] Real `spec_render` test with `mode: "update"` — verifies no spec dir created, bridge manifest written
- [x] Real `spec_ingest` test with update mode — verifies raw file reading, no rigid parsing
- [x] All 15 spec-build tests pass
- [x] Full test suite: no regressions (17 pre-existing failures in fetchGithub/GitlabIssues)
- [x] Biome linter clean