### PR TITLE
feat: fix: forward all opts through AgentPool.getAgent() to MCP/API sub-factories

### DIFF
--- a/src/agents/pool.js
+++ b/src/agents/pool.js
@@ -149,19 +149,20 @@ export class AgentPool {
    * Get an agent instance for a given role and scope.
    *
    * @param {string} role - Agent role from config (issueSelector, planner, etc.)
-   * @param {{ scope?: "workspace" | "repo", mode?: "cli" | "api" | "mcp" }} [opts]
+   * @param {Record<string, unknown> & { scope?: "workspace" | "repo", mode?: "cli" | "api" | "mcp" }} [opts]
    * @returns {{ agentName: string, agent: import("./_base.js").AgentAdapter }}
    */
-  getAgent(role, { scope = "repo", mode = "cli" } = {}) {
+  getAgent(role, opts = {}) {
+    const { scope = "repo", mode = "cli", ...rest } = opts;
     const agentName = this._roleAgentName(role);
     const cwd = scope === "workspace" ? this.workspaceDir : this.repoRoot;
 
     if (mode === "api") {
-      return this._getApiAgent(role, { scope });
+      return this._getApiAgent(role, { scope, ...rest });
     }
 
     if (mode === "mcp") {
-      return this._getMcpAgent(role, { scope });
+      return this._getMcpAgent(role, { scope, ...rest });
     }
 
     if (mode !== "cli") {

--- a/test/agent-pool.test.js
+++ b/test/agent-pool.test.js
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AgentPool } from "../src/agents/pool.js";
+import { CoderConfigSchema } from "../src/config.js";
+
+function makePool() {
+  return new AgentPool({
+    config: CoderConfigSchema.parse({}),
+    workspaceDir: "/tmp",
+    repoRoot: "/tmp",
+    passEnv: [],
+  });
+}
+
+test("AgentPool forwards MCP options to _getMcpAgent", () => {
+  const pool = makePool();
+  const { agentName } = pool.getAgent("stitch", {
+    mode: "mcp",
+    transport: "stdio",
+    serverCommand: "node",
+    serverName: "my-stitch",
+  });
+  assert.equal(agentName, "my-stitch");
+});
+
+test("AgentPool forwards API options to _getApiAgent", () => {
+  const pool = makePool();
+  const { agentName } = pool.getAgent("gemini", {
+    mode: "api",
+    provider: "anthropic",
+  });
+  assert.equal(agentName, "anthropic-api");
+});


### PR DESCRIPTION
# Metadata
Source: local
Issue ID: REV-02
Repo Root: .
Difficulty: 3

# Problem
In `src/agents/pool.js`, the `AgentPool.getAgent` method is currently dropping any options beyond `scope` and `mode` because it destructurizes its second parameter inline:
```javascript
  getAgent(role, { scope = "repo", mode = "cli" } = {}) {