### PR TITLE
fix: use explicit env key for McpAgent auth header (REV-09)

### DIFF
--- a/src/agents/mcp-agent.js
+++ b/src/agents/mcp-agent.js
@@ -42,6 +42,7 @@ export class McpAgent extends AgentAdapter {
    *   serverArgs?: string[],
    *   serverUrl?: string,
    *   authHeader?: string,
+   *   apiKeyEnvVar?: string,
    *   env?: Record<string, string>,
    *   serverName?: string,
    *   retries?: number,
@@ -55,6 +56,7 @@ export class McpAgent extends AgentAdapter {
     this.serverArgs = opts.serverArgs || [];
     this.serverUrl = opts.serverUrl || "";
     this.authHeader = opts.authHeader || "";
+    this.apiKeyEnvVar = opts.apiKeyEnvVar || "";
     this.env = opts.env || {};
     this.serverName = opts.serverName || "mcp-server";
     this._retries = opts.retries ?? 3;
@@ -122,7 +124,9 @@ export class McpAgent extends AgentAdapter {
         const requestInit = {};
 
         if (this.authHeader) {
-          const apiKey = Object.values(this.env)[0] || "";
+          const apiKey = this.apiKeyEnvVar
+            ? this.env[this.apiKeyEnvVar] || ""
+            : Object.values(this.env)[0] || "";
           if (apiKey) {
             requestInit.headers = { [this.authHeader]: apiKey };
           }

--- a/src/agents/pool.js
+++ b/src/agents/pool.js
@@ -219,7 +219,7 @@ export class AgentPool {
   /**
    * Get or create an MCP agent for a given server config.
    * @param {string} role
-   * @param {{ transport?: "stdio" | "http", serverCommand?: string, serverArgs?: string[], serverUrl?: string, authHeader?: string, env?: Record<string, string>, serverName?: string }} [opts]
+   * @param {{ transport?: "stdio" | "http", serverCommand?: string, serverArgs?: string[], serverUrl?: string, authHeader?: string, apiKeyEnvVar?: string, env?: Record<string, string>, serverName?: string }} [opts]
    */
   _getMcpAgent(role, opts = {}) {
     const transport = opts.transport || "stdio";
@@ -252,6 +252,7 @@ export class AgentPool {
           serverArgs: opts.serverArgs || [],
           serverUrl,
           authHeader: opts.authHeader || "",
+          apiKeyEnvVar: opts.apiKeyEnvVar || "",
           env: opts.env || {},
           serverName,
           retries: retryCfg?.retries ?? 3,


### PR DESCRIPTION
## Summary
- Adds `apiKeyEnvVar` option to `McpAgent` constructor, allowing callers to specify which env key holds the API token instead of relying on `Object.values(env)[0]` (insertion-order dependent).
- Forwards `apiKeyEnvVar` through `AgentPool._getMcpAgent` to the `McpAgent` constructor.
- Falls back to the old `Object.values(env)[0]` behavior when `apiKeyEnvVar` is not set, preserving backward compatibility.

## Test plan
- [x] `npx biome check` passes on both changed files
- [x] Full test suite (481 tests) passes with 0 failures
- [ ] Manual verification: configure an MCP agent with `apiKeyEnvVar` pointing to the correct env key alongside unrelated env vars — confirm the correct token is used