### PR TITLE
fix: unique tmp paths in atomicWriteJson (REV-04)

### DIFF
--- a/src/state/workflow-state.js
+++ b/src/state/workflow-state.js
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   access,
   mkdir,
@@ -47,7 +48,7 @@ function nowIso() {
 
 async function atomicWriteJson(filePath, data) {
   const dir = path.dirname(filePath);
-  const tmpPath = filePath + ".tmp";
+  const tmpPath = `${filePath}.${randomUUID().slice(0, 8)}.tmp`;
   let op = "mkdir";
   try {
     await mkdir(dir, { recursive: true });
@@ -56,6 +57,9 @@ async function atomicWriteJson(filePath, data) {
     op = "rename";
     await rename(tmpPath, filePath);
   } catch (err) {
+    try {
+      await unlink(tmpPath);
+    } catch {}
     const code = err.code ? ` (${err.code})` : "";
     throw new Error(
       `Failed to write state ${filePath} [${op}]${code}: ${err.message}`,


### PR DESCRIPTION
## Summary
- Use `randomUUID().slice(0, 8)` for temporary file names in `atomicWriteJson()` instead of deterministic `.tmp` suffix, preventing cross-process clobber when concurrent writes target the same state file.
- Clean up the temporary file in the catch block before re-throwing, preventing stale `.tmp` files from accumulating on failure.
- Added `import { randomUUID } from "node:crypto"` (`unlink` was already imported).

## Test plan
- [x] `npx biome check src/state/workflow-state.js` passes
- [x] All 686 tests pass (`node --test test/*.test.js`)