### PR TITLE
fix: biome formatting and ENOTEMPTY race in CI

### DIFF
--- a/test/develop-loop-lock-order.test.js
+++ b/test/develop-loop-lock-order.test.js
@@ -16,9 +16,7 @@ test("runDevelopLoop: loop path keeps ensureCleanLoopStart and saveLoopState ins
   );
   const src = readFileSync(path, "utf8");
 
-  const loopLockOpen = src.indexOf(
-    "await withDevelopPipelineLock(",
-  );
+  const loopLockOpen = src.indexOf("await withDevelopPipelineLock(");
   assert.notEqual(
     loopLockOpen,
     -1,

--- a/test/workflow-launcher-completion.test.js
+++ b/test/workflow-launcher-completion.test.js
@@ -90,7 +90,7 @@ async function runLauncherNormalCompletionFixture(result, opts = {}) {
     const snap = await loadWorkflowSnapshot(ws);
     return { loop, snap };
   } finally {
-    rmSync(ws, { recursive: true, force: true });
+    rmSync(ws, { recursive: true, force: true, maxRetries: 3 });
   }
 }
 
@@ -214,6 +214,6 @@ test("launcher non-develop: does not sync develop loop-state into actor before t
     );
     assert.equal(snap.context?.activeAgent, "gemini");
   } finally {
-    rmSync(ws, { recursive: true, force: true });
+    rmSync(ws, { recursive: true, force: true, maxRetries: 3 });
   }
 });


### PR DESCRIPTION
## Summary
- Collapse multi-line `indexOf` call in `develop-loop-lock-order.test.js` to satisfy biome formatter (lint failure)
- Add `maxRetries: 3` to `rmSync` cleanup in `workflow-launcher-completion.test.js` to handle ENOTEMPTY race from SQLite WAL files still being written after `actor.stop()` + `drainWriteChain` (test flake on Node 22)

Fixes CI failures on PR #285.

## Test plan
- [x] `npx biome check` passes on both files
- [x] `node --test test/workflow-launcher-completion.test.js` passes 3/3 runs
- [x] Full suite: 754/754 pass