### PR TITLE
fix: use login shell in runShellSync fallback for full user PATH

### DIFF
--- a/src/systemd-run.js
+++ b/src/systemd-run.js
@@ -194,7 +194,7 @@ export function runShellSync(
 
   const fallbackEnv = { ...(env || process.env) };
   delete fallbackEnv.CLAUDECODE;
-  const res = spawnSync("bash", ["-c", maybeTmpFile(command)], {
+  const res = spawnSync("bash", ["-lc", maybeTmpFile(command)], {
     cwd,
     env: fallbackEnv,
     encoding: "utf8",

--- a/src/systemd-run.js
+++ b/src/systemd-run.js
@@ -203,7 +203,7 @@ export function runShellSync(
   });
   const io = withSpawnErrorText(res);
   return {
-    cmd: ["bash", "-c", command],
+    cmd: ["bash", "-lc", command],
     exitCode: safeStatus(res),
     stdout: io.stdout,
     stderr: io.stderr,

--- a/src/test-runner.js
+++ b/src/test-runner.js
@@ -34,11 +34,12 @@ export function detectTestCommand(repoDir) {
   return null;
 }
 
-export function runTestCommand(repoDir, argv) {
-  const res = spawnSync(argv[0], argv.slice(1), {
+export function runTestCommand(repoDir, argv, spawnFn = spawnSync) {
+  const res = spawnFn(argv[0], argv.slice(1), {
     cwd: repoDir,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
+    env: process.env,
   });
   const stderr = res.stderr || "";
   return {

--- a/test/repro-gh-60.test.js
+++ b/test/repro-gh-60.test.js
@@ -36,3 +36,12 @@ test("GH-60: strip CLAUDECODE from runShellSync", async () => {
     else process.env.CLAUDECODE = orig;
   }
 });
+
+test("runShellSync fallback uses login shell (bash -lc)", () => {
+  const res = runShellSync("shopt login_shell", { preferSystemd: false });
+  assert.match(
+    res.stdout,
+    /login_shell\s+on/,
+    "fallback path should use bash -lc so user profile PATH is available",
+  );
+});

--- a/test/test-runner.test.js
+++ b/test/test-runner.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import process from "node:process";
 import test from "node:test";
 import {
   loadTestConfig,
@@ -35,6 +36,20 @@ test("runTestCommand returns exitCode 0 for successful command", () => {
 test("runTestCommand preserves specific exit codes", () => {
   const res = runTestCommand(os.tmpdir(), ["node", "-e", "process.exit(42)"]);
   assert.equal(res.exitCode, 42);
+});
+
+test("runTestCommand explicitly passes process.env to spawn options", () => {
+  let capturedOptions;
+  const mockSpawn = (_cmd, _args, opts) => {
+    capturedOptions = opts;
+    return { status: 0, stdout: "", stderr: "" };
+  };
+  runTestCommand(os.tmpdir(), ["node", "--version"], mockSpawn);
+  assert.ok(
+    "env" in capturedOptions,
+    "env should be explicitly set in options",
+  );
+  assert.strictEqual(capturedOptions.env, process.env);
 });
 
 test("loadTestConfig: testConfigPath to unified coder.json accepts test.command object", () => {


### PR DESCRIPTION
## Summary

- Changes `bash -c` to `bash -lc` in `runShellSync`'s fallback (non-systemd) path so user profile PATH entries (go, cargo, python, etc.) are available
- Fixes the inconsistency where `requireCommandOnPath()` and `readEnvFromLoginShell()` already use `bash -lc` but the test runner did not

Closes #306
Depends on #309 (ISSUE-308: adds `env: process.env` to `runTestCommand`)

## Changes

- `src/systemd-run.js:197`: `bash -c` → `bash -lc`
- `test/repro-gh-60.test.js`: New test verifying `shopt login_shell` is `on` in the fallback path

## Test plan

- [x] New test passes: `node --test test/repro-gh-60.test.js` (3/3)
- [x] Full suite passes: 803/803 tests
- [ ] Manual: start coder MCP from systemd, run develop workflow on a Go project, verify `go test` is found