### PR TITLE
fix: move ensureGitignore() after branch checkout (#317)

### DIFF
--- a/src/machines/develop/_shared.js
+++ b/src/machines/develop/_shared.js
@@ -107,7 +107,7 @@ export function ensureGitignore(workspaceDir) {
     ? readFileSync(gitignorePath, "utf8")
     : "";
   const giLines = giContent.split("\n").map((l) => l.trim());
-  const needed = [".coder/", ".gemini/", ".coder/logs/"];
+  const needed = [".coder/", ".gemini/"];
   const missing = needed.filter((rule) => !giLines.includes(rule));
   if (missing.length > 0) {
     const suffix = giContent.endsWith("\n") || giContent === "" ? "" : "\n";

--- a/src/machines/develop/issue-draft.machine.js
+++ b/src/machines/develop/issue-draft.machine.js
@@ -259,12 +259,7 @@ export default defineMachine({
       });
     }
 
-    // Ensure .gitignore rules exist AFTER cleanup (checkout -- . reverts .gitignore
-    // to committed version, which may lack .coder/ rules).
-    ensureGitignore(ctx.workspaceDir);
-    mkdirSync(ctx.artifactsDir, { recursive: true });
-
-    // Verify clean repo
+    // Verify clean repo FIRST — before any writes that could block checkout.
     gitCleanOrThrow(repoRoot);
     state.steps.verifiedCleanRepo = true;
     await saveState(ctx.workspaceDir, state);
@@ -310,6 +305,13 @@ export default defineMachine({
       forceRecreate: input.force,
       signal: ctx.signal,
     });
+
+    // Ensure .gitignore/.geminiignore rules exist AFTER all branch operations
+    // complete. Must come after checkout (which may revert .gitignore to
+    // committed version) and after ensureBranch (which may also switch branches).
+    // Running before checkout would dirty .gitignore, blocking branch switches (#317).
+    ensureGitignore(ctx.workspaceDir);
+    mkdirSync(ctx.artifactsDir, { recursive: true });
 
     // Draft ISSUE.md
     ctx.log({ event: "step2_draft_issue", issue: input.issue });


### PR DESCRIPTION
## Summary

- Reorders `ensureGitignore()` to run **after** all branch checkout operations in `issue-draft.machine.js`, preventing dirty `.gitignore` from blocking `git checkout <baseBranch>`
- Removes redundant `.coder/logs/` from the `ensureGitignore` needed list (already covered by `.coder/`)

## Root cause

`ensureGitignore()` was called before the base branch checkout. It appended `.coder/logs/` to `.gitignore` (even though `.coder/` already covers it), dirtying the file. While `gitCleanOrThrow()` allows `.gitignore` changes via its allowlist, `git checkout` does not — causing all dependent-issue workflows to fail deterministically on all 3 retry attempts.

## Changes

- **`src/machines/develop/_shared.js`**: Remove `.coder/logs/` from `needed` array
- **`src/machines/develop/issue-draft.machine.js`**: Move `ensureGitignore()` + `mkdirSync()` after `gitCleanOrThrow()`, base branch checkout, and `ensureBranch()`

## Test plan

- [x] `node --test` — 806/807 pass (1 pre-existing failure in spec-architect)
- [x] `npx biome check` — clean

Closes #317