### PR TITLE
fix: prevent MCP HTTP session leak during long workflows (#316)

### DIFF
--- a/bin/coder-mcp.js
+++ b/bin/coder-mcp.js
@@ -150,6 +150,8 @@ async function runStdio(workspace) {
 
 const SESSION_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const SESSION_CLEANUP_INTERVAL_MS = 60 * 1000; // 1 minute
+const SSE_KEEPALIVE_INTERVAL_MS = 30_000; // 30 seconds
+const MAX_SESSIONS = 50;
 
 async function runHttp({ workspace, host, port, routePath, allowedHosts }) {
   if (process.env.CODER_ALLOW_ANY_WORKSPACE === "1") {
@@ -226,6 +228,44 @@ async function runHttp({ workspace, host, port, routePath, allowedHosts }) {
           return;
         }
 
+        // Evict oldest session when at capacity to prevent unbounded growth (#316)
+        if (transports.size >= MAX_SESSIONS) {
+          let oldestSid = null;
+          let oldestTime = Infinity;
+          for (const [sid, ts] of sessionLastSeen) {
+            if (ts < oldestTime) {
+              oldestSid = sid;
+              oldestTime = ts;
+            }
+          }
+          if (oldestSid) {
+            process.stderr.write(
+              `[coder-mcp] Session limit reached (${MAX_SESSIONS}). ` +
+                `Evicting oldest session ${oldestSid} ` +
+                `(age: ${Math.round((Date.now() - oldestTime) / 1000)}s).\n`,
+            );
+            const oldTransport = transports.get(oldestSid);
+            if (oldTransport) {
+              try {
+                await oldTransport.close();
+              } catch {
+                /* best-effort */
+              }
+              transports.delete(oldestSid);
+            }
+            const oldServer = servers.get(oldestSid);
+            if (oldServer) {
+              try {
+                await oldServer.close();
+              } catch {
+                /* best-effort */
+              }
+              servers.delete(oldestSid);
+            }
+            sessionLastSeen.delete(oldestSid);
+          }
+        }
+
         const mcpServer = buildServer(workspace, { httpMode: true });
         // onsessioninitialized must be a constructor option — the Node.js
         // StreamableHTTPServerTransport wrapper does not forward property
@@ -273,7 +313,11 @@ async function runHttp({ workspace, host, port, routePath, allowedHosts }) {
     ? `${routePath}health`
     : `${routePath}/health`;
   app.get(healthPath, (_req, res) =>
-    res.json({ status: "ok", sessions: transports.size }),
+    res.json({
+      status: "ok",
+      sessions: transports.size,
+      maxSessions: MAX_SESSIONS,
+    }),
   );
 
   app.get(routePath, async (req, res) => {
@@ -286,8 +330,20 @@ async function runHttp({ workspace, host, port, routePath, allowedHosts }) {
       return;
     }
     const transport = transports.get(sessionId);
+    sessionLastSeen.set(sessionId, Date.now());
     try {
       await transport.handleRequest(req, res);
+      // SSE keepalive: send periodic comment frames to prevent TCP idle
+      // timeouts and keep sessionLastSeen fresh for the cleanup sweep (#316).
+      const keepalive = setInterval(() => {
+        if (res.destroyed || res.writableEnded) {
+          clearInterval(keepalive);
+          return;
+        }
+        res.write(":keepalive\n\n");
+        sessionLastSeen.set(sessionId, Date.now());
+      }, SSE_KEEPALIVE_INTERVAL_MS);
+      res.on("close", () => clearInterval(keepalive));
     } catch (err) {
       console.error("[coder-mcp] HTTP transport error (GET):", err);
       if (!res.headersSent) {
@@ -310,6 +366,7 @@ async function runHttp({ workspace, host, port, routePath, allowedHosts }) {
       return;
     }
     const transport = transports.get(sessionId);
+    sessionLastSeen.set(sessionId, Date.now());
     try {
       await transport.handleRequest(req, res);
     } catch (err) {

--- a/bin/coder-mcp.js
+++ b/bin/coder-mcp.js
@@ -275,6 +275,7 @@ async function runHttp({ workspace, host, port, routePath, allowedHosts }) {
           onsessioninitialized: (newSessionId) => {
             transports.set(newSessionId, transport);
             servers.set(newSessionId, mcpServer);
+            sessionLastSeen.set(newSessionId, Date.now());
           },
         });
 

--- a/bin/coder-mcp.js
+++ b/bin/coder-mcp.js
@@ -247,25 +247,28 @@ async function runHttp({ workspace, host, port, routePath, allowedHosts }) {
                 `Evicting oldest session ${oldestSid} ` +
                 `(age: ${Math.round((Date.now() - oldestTime) / 1000)}s).\n`,
             );
+            // Remove from maps synchronously so capacity is freed immediately
+            // and concurrent POSTs see the updated count without a TOCTOU gap.
             const oldTransport = transports.get(oldestSid);
+            const oldServer = servers.get(oldestSid);
+            transports.delete(oldestSid);
+            servers.delete(oldestSid);
+            sessionLastSeen.delete(oldestSid);
+            // Close resources asynchronously (best-effort cleanup).
             if (oldTransport) {
               try {
                 await oldTransport.close();
               } catch {
                 /* best-effort */
               }
-              transports.delete(oldestSid);
             }
-            const oldServer = servers.get(oldestSid);
             if (oldServer) {
               try {
                 await oldServer.close();
               } catch {
                 /* best-effort */
               }
-              servers.delete(oldestSid);
             }
-            sessionLastSeen.delete(oldestSid);
           }
         }
 

--- a/bin/coder-mcp.js
+++ b/bin/coder-mcp.js
@@ -172,6 +172,9 @@ async function runHttp({ workspace, host, port, routePath, allowedHosts }) {
   const servers = new Map();
   /** @type {Map<string, number>} */
   const sessionLastSeen = new Map();
+  /** Guards against TOCTOU race: concurrent POSTs could bypass MAX_SESSIONS
+   *  because the capacity check and session registration span async work. */
+  let pendingCreates = 0;
 
   // Workaround: @hono/node-server (used internally by StreamableHTTPServerTransport)
   // injects Content-Length and buffers SSE responses when Transfer-Encoding: chunked
@@ -229,7 +232,7 @@ async function runHttp({ workspace, host, port, routePath, allowedHosts }) {
         }
 
         // Evict oldest session when at capacity to prevent unbounded growth (#316)
-        if (transports.size >= MAX_SESSIONS) {
+        if (transports.size + pendingCreates >= MAX_SESSIONS) {
           let oldestSid = null;
           let oldestTime = Infinity;
           for (const [sid, ts] of sessionLastSeen) {
@@ -266,30 +269,35 @@ async function runHttp({ workspace, host, port, routePath, allowedHosts }) {
           }
         }
 
-        const mcpServer = buildServer(workspace, { httpMode: true });
-        // onsessioninitialized must be a constructor option — the Node.js
-        // StreamableHTTPServerTransport wrapper does not forward property
-        // setters for it (MCP SDK bug).
-        transport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: () => randomUUID(),
-          onsessioninitialized: (newSessionId) => {
-            transports.set(newSessionId, transport);
-            servers.set(newSessionId, mcpServer);
-            sessionLastSeen.set(newSessionId, Date.now());
-          },
-        });
+        pendingCreates++;
+        try {
+          const mcpServer = buildServer(workspace, { httpMode: true });
+          // onsessioninitialized must be a constructor option — the Node.js
+          // StreamableHTTPServerTransport wrapper does not forward property
+          // setters for it (MCP SDK bug).
+          transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            onsessioninitialized: (newSessionId) => {
+              transports.set(newSessionId, transport);
+              servers.set(newSessionId, mcpServer);
+              sessionLastSeen.set(newSessionId, Date.now());
+            },
+          });
 
-        transport.onclose = async () => {
-          const sid = transport.sessionId;
-          if (!sid) return;
-          transports.delete(sid);
-          sessionLastSeen.delete(sid);
-          const s = servers.get(sid);
-          servers.delete(sid);
-          if (s) await s.close().catch(() => {});
-        };
+          transport.onclose = async () => {
+            const sid = transport.sessionId;
+            if (!sid) return;
+            transports.delete(sid);
+            sessionLastSeen.delete(sid);
+            const s = servers.get(sid);
+            servers.delete(sid);
+            if (s) await s.close().catch(() => {});
+          };
 
-        await mcpServer.connect(transport);
+          await mcpServer.connect(transport);
+        } finally {
+          pendingCreates--;
+        }
       }
 
       if (transport.sessionId)
@@ -336,15 +344,23 @@ async function runHttp({ workspace, host, port, routePath, allowedHosts }) {
       await transport.handleRequest(req, res);
       // SSE keepalive: send periodic comment frames to prevent TCP idle
       // timeouts and keep sessionLastSeen fresh for the cleanup sweep (#316).
-      const keepalive = setInterval(() => {
-        if (res.destroyed || res.writableEnded) {
-          clearInterval(keepalive);
-          return;
-        }
-        res.write(":keepalive\n\n");
-        sessionLastSeen.set(sessionId, Date.now());
-      }, SSE_KEEPALIVE_INTERVAL_MS);
-      res.on("close", () => clearInterval(keepalive));
+      // Only start if the response is still open (it's an SSE stream).
+      if (!res.destroyed && !res.writableEnded) {
+        const keepalive = setInterval(() => {
+          if (res.destroyed || res.writableEnded) {
+            clearInterval(keepalive);
+            return;
+          }
+          try {
+            res.write(":keepalive\n\n");
+          } catch {
+            clearInterval(keepalive);
+            return;
+          }
+          sessionLastSeen.set(sessionId, Date.now());
+        }, SSE_KEEPALIVE_INTERVAL_MS);
+        res.on("close", () => clearInterval(keepalive));
+      }
     } catch (err) {
       console.error("[coder-mcp] HTTP transport error (GET):", err);
       if (!res.headersSent) {


### PR DESCRIPTION
## Summary

- Adds `sessionLastSeen` tracking to GET and DELETE HTTP handlers (previously only POST updated it)
- Adds SSE keepalive heartbeat (`:keepalive\n\n` every 30s) on GET SSE streams to prevent TCP idle timeouts
- Adds session capacity limit (`MAX_SESSIONS = 50`) with LRU eviction to prevent unbounded session growth
- Enhances health endpoint to report `maxSessions`

## Root cause

Three contributing factors caused client disconnects during long workflow runs:

1. **GET/DELETE handlers never called `sessionLastSeen.set()`** — sessions using SSE streaming appeared inactive and could be reaped by the cleanup sweep
2. **No SSE keepalive** — idle TCP connections were silently closed by the OS/proxies
3. **No session cap** — 189 sessions accumulated in ~45min, each holding a full `McpServer` + transport + SSE response objects

## Changes

- **`bin/coder-mcp.js`**: All fixes in this single file
  - New constants: `SSE_KEEPALIVE_INTERVAL_MS` (30s), `MAX_SESSIONS` (50)
  - GET handler: `sessionLastSeen` update + keepalive interval with cleanup on `res.close`
  - DELETE handler: `sessionLastSeen` update
  - POST handler: LRU eviction when at capacity (with stderr logging)
  - Health endpoint: reports `maxSessions`

## Test plan

- [x] `node --test` — 806/807 pass (1 pre-existing failure in spec-architect)
- [x] `npx biome check` — clean
- [ ] Manual: start HTTP server, verify `curl .../mcp/health` reports `maxSessions: 50`

Closes #316