### PR TITLE
fix: drain sqlite write inside workspace chain

### DIFF
--- a/src/state/workflow-state.js
+++ b/src/state/workflow-state.js
@@ -166,6 +166,9 @@ export async function saveWorkflowSnapshot(
   };
   let writeErr;
   let guarded = false;
+  // SQLite persistence is part of the chain so drainWriteChain() covers it.
+  // Otherwise fire-and-forget callers (e.g. actor.subscribe) leave SQLite tmp
+  // files in flight after drain returns, breaking workspace teardown.
   const chain = getWriteChain(workspaceDir)
     .then(async () => {
       if (await readGuardRunId(statePath, guardRunId)) {
@@ -173,6 +176,7 @@ export async function saveWorkflowSnapshot(
         return;
       }
       await writeJson(statePath, payload);
+      await persistSnapshotToSqlite(sqlitePath, payload);
     })
     .catch((e) => {
       writeErr = e;
@@ -181,7 +185,6 @@ export async function saveWorkflowSnapshot(
   await chain;
   if (guarded) return null;
   if (writeErr) throw writeErr;
-  await persistSnapshotToSqlite(sqlitePath, payload);
   return payload;
 }
 
@@ -208,6 +211,7 @@ export async function saveWorkflowTerminalState(
   };
   let writeErr;
   let guarded = false;
+  // SQLite persistence is part of the chain so drainWriteChain() covers it.
   const chain = getWriteChain(workspaceDir)
     .then(async () => {
       if (await readGuardRunId(statePath, guardRunId)) {
@@ -215,6 +219,7 @@ export async function saveWorkflowTerminalState(
         return;
       }
       await writeJson(statePath, payload);
+      await persistSnapshotToSqlite(sqlitePath, payload);
     })
     .catch((e) => {
       writeErr = e;
@@ -223,7 +228,6 @@ export async function saveWorkflowTerminalState(
   await chain;
   if (guarded) return null;
   if (writeErr) throw writeErr;
-  await persistSnapshotToSqlite(sqlitePath, payload);
   return payload;
 }
 


### PR DESCRIPTION
## Summary

`saveWorkflowSnapshot` / `saveWorkflowTerminalState` awaited the JSON write through the workspace chain, then awaited the SQLite write **outside** the chain. Fire-and-forget callers (actor.subscribe) discarded the returned promise, so `drainWriteChain()` returned while a SQLite tmp file was still being written into `.coder/`.

## Symptom

Intermittent ENOTEMPTY failures on CI in tests that call `rmSync` on the workspace dir after the test body (workflow-launcher-completion, develop-runid). Examples:

- ``ENOTEMPTY: directory not empty, rmdir '/tmp/coder-launcher-e2e-fSt1d9/.coder'`` (PR #295 CI run)
- Same pattern on PR #294 / PR #293 CI runs

Reproduces only on slow CI runners — not locally — because the race between the SQLite tmp file and `rmSync` is timing-dependent.

## Fix

Move `persistSnapshotToSqlite` into the chain, so a single `drainWriteChain()` call covers both writes.

## Test plan

- [x] All 806 local tests pass
- [ ] CI green